### PR TITLE
feat: add Anthropic theme and stabilize SSH browsing

### DIFF
--- a/src/renderer/components/sidebar/ThemeSettingsPanel.tsx
+++ b/src/renderer/components/sidebar/ThemeSettingsPanel.tsx
@@ -9,6 +9,7 @@ import { getPresetById } from "./themeSettings/themePresets";
 import {
   applyFontFamilyToDocument,
   applyPaletteToDocument,
+  applyThemePresetToDocument,
   applyStreamCursorToDocument,
   applyThemeModeToDocument,
   DEFAULT_THEME_SETTINGS,
@@ -130,6 +131,7 @@ export function ThemeSettingsPanel({
     const effectiveDark =
       form.mode === "system" ? systemDark : form.mode === "dark";
     applyThemeModeToDocument(form.mode);
+    applyThemePresetToDocument(form.presetId);
     const palette = resolveActivePalette(form, effectiveDark);
     applyPaletteToDocument(palette);
 

--- a/src/renderer/components/sidebar/mainSidebar/SshConnectWizard.tsx
+++ b/src/renderer/components/sidebar/mainSidebar/SshConnectWizard.tsx
@@ -43,12 +43,18 @@ type CredentialOption = {
   hasSecret: boolean;
 };
 
+const normalizeRemotePath = (path: string): string => {
+  const segments = path.trim().split("/").filter(Boolean);
+  return segments.length > 0 ? `/${segments.join("/")}` : "/";
+};
+
 const buildSshUrl = (
   host: string,
   port: number,
   username: string,
   remotePath: string
-): string => `ssh://${username}@${host}:${port}${remotePath}`;
+): string =>
+  `ssh://${username}@${host}:${port}${normalizeRemotePath(remotePath)}`;
 
 export function SshConnectWizard({
   onConfirm,
@@ -84,6 +90,8 @@ export function SshConnectWizard({
     []
   );
   const [showSavedList, setShowSavedList] = useState(false);
+  const directoryRequestIdRef = useRef(0);
+  const pendingNavigationPathRef = useRef<string | null>(null);
   const wizardRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -106,13 +114,29 @@ export function SshConnectWizard({
       if (!sessionId) {
         return;
       }
+      const normalizedPath = normalizeRemotePath(path);
+      const requestId = ++directoryRequestIdRef.current;
       setIsLoadingEntries(true);
       setEntriesError(null);
       try {
-        const result = await window.snow.sshListDirectory(sessionId, path);
-        setEntries(result);
-        setRemotePath(path);
+        const result = await window.snow.sshListDirectory(
+          sessionId,
+          normalizedPath
+        );
+        if (requestId !== directoryRequestIdRef.current) {
+          return;
+        }
+        setEntries(
+          result.map((entry) => ({
+            ...entry,
+            path: normalizeRemotePath(entry.path),
+          }))
+        );
+        setRemotePath(normalizedPath);
       } catch (err) {
+        if (requestId !== directoryRequestIdRef.current) {
+          return;
+        }
         setEntriesError(
           err instanceof Error
             ? err.message
@@ -122,7 +146,9 @@ export function SshConnectWizard({
         );
         setEntries([]);
       } finally {
-        setIsLoadingEntries(false);
+        if (requestId === directoryRequestIdRef.current) {
+          setIsLoadingEntries(false);
+        }
       }
     },
     [sessionId, t]
@@ -245,27 +271,57 @@ export function SshConnectWizard({
     }
   };
 
-  const handleEntryClick = (entry: SshDirectoryEntry): void => {
+  const handleEntryClick = (
+    entry: SshDirectoryEntry,
+    event: React.MouseEvent<HTMLDivElement>
+  ): void => {
+    // The first click already opens a directory. Ignore the second click from
+    // a double-click so a fast response cannot navigate into a same-named child.
+    if (event.detail > 1) {
+      return;
+    }
+
+    const entryPath = normalizeRemotePath(entry.path);
     if (entry.isDirectory) {
-      const newPath = entry.path;
-      setSelectedPath(newPath);
-      setPathHistory((prev) => [...prev, newPath]);
-      void loadEntries(newPath);
+      if (
+        entryPath === remotePath ||
+        pendingNavigationPathRef.current === entryPath
+      ) {
+        setSelectedPath(entryPath);
+        return;
+      }
+
+      pendingNavigationPathRef.current = entryPath;
+      setSelectedPath(entryPath);
+      setPathHistory((prev) =>
+        prev[prev.length - 1] === entryPath ? prev : [...prev, entryPath]
+      );
+      void loadEntries(entryPath).finally(() => {
+        if (pendingNavigationPathRef.current === entryPath) {
+          pendingNavigationPathRef.current = null;
+        }
+      });
     } else {
-      setSelectedPath(entry.path);
+      setSelectedPath(entryPath);
     }
   };
 
   const handleBreadcrumbClick = (path: string): void => {
-    const index = pathHistory.indexOf(path);
+    const normalizedPath = normalizeRemotePath(path);
+    const index = pathHistory.indexOf(normalizedPath);
     if (index >= 0) {
       setPathHistory((prev) => prev.slice(0, index + 1));
     }
-    void loadEntries(path);
+    pendingNavigationPathRef.current = normalizedPath;
+    void loadEntries(normalizedPath).finally(() => {
+      if (pendingNavigationPathRef.current === normalizedPath) {
+        pendingNavigationPathRef.current = null;
+      }
+    });
   };
 
   const handleRefresh = (): void => {
-    void loadEntries(remotePath);
+    void loadEntries(normalizeRemotePath(remotePath));
   };
 
   const handleConfirm = (): void => {
@@ -293,6 +349,8 @@ export function SshConnectWizard({
   };
 
   const handleBack = (): void => {
+    directoryRequestIdRef.current += 1;
+    pendingNavigationPathRef.current = null;
     if (sessionId) {
       void window.snow.sshDisconnect(sessionId);
       setSessionId(null);
@@ -691,7 +749,7 @@ export function SshConnectWizard({
                         isSelected ? " selected" : ""
                       }${!entry.isDirectory ? " file" : ""}`}
                       key={entry.path}
-                      onClick={() => handleEntryClick(entry)}
+                      onClick={(event) => handleEntryClick(entry, event)}
                       title={entry.path}
                     >
                       {entry.isDirectory ? (

--- a/src/renderer/components/sidebar/mainSidebar/SshConnectWizard.tsx
+++ b/src/renderer/components/sidebar/mainSidebar/SshConnectWizard.tsx
@@ -44,7 +44,7 @@ type CredentialOption = {
 };
 
 const normalizeRemotePath = (path: string): string => {
-  const segments = path.trim().split("/").filter(Boolean);
+  const segments = path.split("/").filter(Boolean);
   return segments.length > 0 ? `/${segments.join("/")}` : "/";
 };
 
@@ -110,9 +110,9 @@ export function SshConnectWizard({
   }, []);
 
   const loadEntries = useCallback(
-    async (path: string): Promise<void> => {
+    async (path: string): Promise<boolean> => {
       if (!sessionId) {
-        return;
+        return false;
       }
       const normalizedPath = normalizeRemotePath(path);
       const requestId = ++directoryRequestIdRef.current;
@@ -124,7 +124,7 @@ export function SshConnectWizard({
           normalizedPath
         );
         if (requestId !== directoryRequestIdRef.current) {
-          return;
+          return false;
         }
         setEntries(
           result.map((entry) => ({
@@ -133,9 +133,10 @@ export function SshConnectWizard({
           }))
         );
         setRemotePath(normalizedPath);
+        return true;
       } catch (err) {
         if (requestId !== directoryRequestIdRef.current) {
-          return;
+          return false;
         }
         setEntriesError(
           err instanceof Error
@@ -145,6 +146,7 @@ export function SshConnectWizard({
               })
         );
         setEntries([]);
+        return false;
       } finally {
         if (requestId === directoryRequestIdRef.current) {
           setIsLoadingEntries(false);
@@ -293,14 +295,19 @@ export function SshConnectWizard({
 
       pendingNavigationPathRef.current = entryPath;
       setSelectedPath(entryPath);
-      setPathHistory((prev) =>
-        prev[prev.length - 1] === entryPath ? prev : [...prev, entryPath]
-      );
-      void loadEntries(entryPath).finally(() => {
-        if (pendingNavigationPathRef.current === entryPath) {
-          pendingNavigationPathRef.current = null;
-        }
-      });
+      void loadEntries(entryPath)
+        .then((loaded) => {
+          if (loaded) {
+            setPathHistory((prev) =>
+              prev[prev.length - 1] === entryPath ? prev : [...prev, entryPath]
+            );
+          }
+        })
+        .finally(() => {
+          if (pendingNavigationPathRef.current === entryPath) {
+            pendingNavigationPathRef.current = null;
+          }
+        });
     } else {
       setSelectedPath(entryPath);
     }
@@ -308,16 +315,21 @@ export function SshConnectWizard({
 
   const handleBreadcrumbClick = (path: string): void => {
     const normalizedPath = normalizeRemotePath(path);
-    const index = pathHistory.indexOf(normalizedPath);
-    if (index >= 0) {
-      setPathHistory((prev) => prev.slice(0, index + 1));
-    }
     pendingNavigationPathRef.current = normalizedPath;
-    void loadEntries(normalizedPath).finally(() => {
-      if (pendingNavigationPathRef.current === normalizedPath) {
-        pendingNavigationPathRef.current = null;
-      }
-    });
+    void loadEntries(normalizedPath)
+      .then((loaded) => {
+        if (loaded) {
+          setPathHistory((prev) => {
+            const index = prev.indexOf(normalizedPath);
+            return index >= 0 ? prev.slice(0, index + 1) : prev;
+          });
+        }
+      })
+      .finally(() => {
+        if (pendingNavigationPathRef.current === normalizedPath) {
+          pendingNavigationPathRef.current = null;
+        }
+      });
   };
 
   const handleRefresh = (): void => {

--- a/src/renderer/components/sidebar/themeSettings/themePresets.ts
+++ b/src/renderer/components/sidebar/themeSettings/themePresets.ts
@@ -511,6 +511,64 @@ const gruvboxDark: ThemePalette = {
   focusRing: "rgba(235, 219, 178, 0.12)",
 };
 
+const anthropicLight: ThemePalette = {
+  bgPrimary: "#faf9f5",
+  bgSecondary: "#f2f0e8",
+  bgTertiary: "#e8e6dc",
+  bgHover: "#eeece4",
+  bgActive: "#dedbd0",
+  chromeBg: "#f7f6f1",
+  appBg: "#e8e6dc",
+  borderColor: "#d9d6ca",
+  borderLight: "#e8e6dc",
+  borderSubtle: "#c4c0b4",
+  textPrimary: "#141413",
+  textSecondary: "#484640",
+  textTertiary: "#706e66",
+  textMuted: "#98958b",
+  accentGreen: "#788c5d",
+  accentGreenBg: "#e9eee3",
+  accentGreenText: "#53653f",
+  accentRed: "#c35d45",
+  accentRedBg: "#f7e4df",
+  accentRedText: "#8b3e31",
+  accentBlue: "#6a9bcc",
+  accentBlueBg: "#e4eef8",
+  accentBlueText: "#3f668c",
+  onSolid: "#faf9f5",
+  selectionBg: "rgba(106, 155, 204, 0.22)",
+  focusRing: "rgba(217, 119, 87, 0.24)",
+};
+
+const anthropicDark: ThemePalette = {
+  bgPrimary: "#141413",
+  bgSecondary: "#1f1f1c",
+  bgTertiary: "#292824",
+  bgHover: "#252521",
+  bgActive: "#37352f",
+  chromeBg: "#191917",
+  appBg: "#141413",
+  borderColor: "#393831",
+  borderLight: "#262520",
+  borderSubtle: "#504d43",
+  textPrimary: "#faf9f5",
+  textSecondary: "#e8e6dc",
+  textTertiary: "#b0aea5",
+  textMuted: "#7f7d74",
+  accentGreen: "#9cad7d",
+  accentGreenBg: "rgba(120, 140, 93, 0.2)",
+  accentGreenText: "#c1d0a5",
+  accentRed: "#e18a72",
+  accentRedBg: "rgba(217, 119, 87, 0.18)",
+  accentRedText: "#f0b1a0",
+  accentBlue: "#8db6df",
+  accentBlueBg: "rgba(106, 155, 204, 0.2)",
+  accentBlueText: "#b5d2ed",
+  onSolid: "#141413",
+  selectionBg: "rgba(106, 155, 204, 0.3)",
+  focusRing: "rgba(217, 119, 87, 0.28)",
+};
+
 export const THEME_PRESETS: ThemePreset[] = [
   {
     id: "snow",
@@ -581,6 +639,13 @@ export const THEME_PRESETS: ThemePreset[] = [
     defaultName: "Gruvbox",
     light: gruvboxLight,
     dark: gruvboxDark,
+  },
+  {
+    id: "anthropic",
+    nameKey: "settings.themePresetAnthropic",
+    defaultName: "Anthropic",
+    light: anthropicLight,
+    dark: anthropicDark,
   },
 ];
 

--- a/src/renderer/components/sidebar/themeSettings/themeSettingsUtils.ts
+++ b/src/renderer/components/sidebar/themeSettings/themeSettingsUtils.ts
@@ -5,7 +5,11 @@ import type {
   ThemeMode,
   ThemeStreamCursor,
 } from "./types";
-import { DEFAULT_THEME_PRESET_ID, getPresetById } from "./themePresets";
+import {
+  DEFAULT_THEME_PRESET_ID,
+  getPresetById,
+  resolvePresetId,
+} from "./themePresets";
 import { themeBgUrl } from "../../../utils/themeBgUrl";
 
 export const THEME_SETTING_NAME = "Theme settings";
@@ -392,6 +396,15 @@ export function applyThemeModeToDocument(mode: ThemeMode): "light" | "dark" {
   return effective;
 }
 
+/** Apply the active preset id so preset-specific typography and surface styling can react. */
+export function applyThemePresetToDocument(presetId: string): void {
+  const root = document.documentElement;
+  const normalizedPresetId = resolvePresetId(
+    presetId.trim() || DEFAULT_THEME_PRESET_ID
+  );
+  root.setAttribute("data-theme-preset", normalizedPresetId);
+}
+
 /**
  * 将自定义字体应用到 document 根元素。传入空字符串时移除自定义字体，
  * 回退到 CSS 中定义的默认字体栈。
@@ -526,6 +539,7 @@ export const applyThemeCacheToDocument = (): "light" | "dark" | null => {
     settings.mode === "system" ? systemDark : settings.mode === "dark";
 
   applyThemeModeToDocument(settings.mode);
+  applyThemePresetToDocument(settings.presetId);
   const palette = resolveActivePalette(settings, isDark);
   applyPaletteToDocument(palette);
 

--- a/src/renderer/hooks/useTheme.ts
+++ b/src/renderer/hooks/useTheme.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import {
   applyFontFamilyToDocument,
   applyPaletteToDocument,
+  applyThemePresetToDocument,
   applyStreamCursorToDocument,
   applyThemeModeToDocument,
   DEFAULT_THEME_SETTINGS,
@@ -36,6 +37,7 @@ export const useTheme = (): {
       const isDark =
         settings.mode === "system" ? systemDark : settings.mode === "dark";
       applyThemeModeToDocument(settings.mode);
+      applyThemePresetToDocument(settings.presetId);
       const palette = resolveActivePalette(settings, isDark);
       applyPaletteToDocument(palette);
 

--- a/src/renderer/i18n/lang/en.ts
+++ b/src/renderer/i18n/lang/en.ts
@@ -1173,6 +1173,7 @@ export const en = {
   "settings.themePresetsInfo":
     "Pick a built-in color scheme. Light and dark variants are bundled together.",
   "settings.themePresetSnow": "Snow",
+  "settings.themePresetAnthropic": "Anthropic",
   "settings.themePresetMidnightBlue": "Midnight Blue",
   "settings.themePresetForestGreen": "Forest Green",
   "settings.themePresetRosePink": "Rose Pink",

--- a/src/renderer/i18n/lang/zh-CN.ts
+++ b/src/renderer/i18n/lang/zh-CN.ts
@@ -1125,6 +1125,7 @@ export const zhCN = {
   "settings.themePresets": "预设主题",
   "settings.themePresetsInfo": "选择内置配色方案，浅色和深色变体打包在一起。",
   "settings.themePresetSnow": "Snow",
+  "settings.themePresetAnthropic": "Anthropic",
   "settings.themePresetMidnightBlue": "午夜蓝",
   "settings.themePresetForestGreen": "森林绿",
   "settings.themePresetRosePink": "玫瑰粉",

--- a/src/renderer/i18n/lang/zh-TW.ts
+++ b/src/renderer/i18n/lang/zh-TW.ts
@@ -1123,6 +1123,7 @@ export const zhTW = {
   "settings.themePresets": "預設主題",
   "settings.themePresetsInfo": "選擇內建配色方案，淺色和深色變體打包在一起。",
   "settings.themePresetSnow": "Snow",
+  "settings.themePresetAnthropic": "Anthropic",
   "settings.themePresetMidnightBlue": "午夜藍",
   "settings.themePresetForestGreen": "森林綠",
   "settings.themePresetRosePink": "玫瑰粉",

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -200,6 +200,12 @@
           background: #0a0a0a;
         }
       }
+      html[data-theme-preset="anthropic"][data-theme="light"] #boot-loader {
+        background: #faf9f5;
+      }
+      html[data-theme-preset="anthropic"][data-theme="dark"] #boot-loader {
+        background: #141413;
+      }
       .boot-logo-wrap {
         display: flex;
         flex-direction: column;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -4920,6 +4920,37 @@ input {
   overflow: visible;
   justify-content: flex-start;
 }
+
+/* Keep the composer in the viewport on short windows. The greeting remains
+   reachable by scrolling in the upper area instead of pushing the composer
+   below the window. */
+@media (max-height: 800px) {
+  .chat-content.is-empty {
+    overflow: hidden;
+    padding-top: clamp(12px, 6vh, 48px);
+    padding-bottom: 0;
+  }
+
+  .chat-content.is-empty .chat-area {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+  }
+
+  .chat-empty-greeting-title {
+    margin-top: 20px;
+  }
+
+  .chat-empty-quick-actions {
+    gap: 8px;
+    margin-top: 28px;
+  }
+
+  .chat-empty-quick-card {
+    padding: 12px 14px;
+  }
+}
+
 /* Has-messages state: chat-area grows to fill, pushing input to bottom */
 .chat-content.has-messages {
   padding-bottom: 0;
@@ -21980,5 +22011,416 @@ input {
   }
   50% {
     opacity: 1;
+  }
+}
+
+/* ===== Anthropic system-wide refinement =====
+   Keep the preset recognizable across the whole workspace instead of only
+   changing the empty-chat greeting. The app remains dense and operational,
+   while surfaces, type roles, controls, and state colors share one visual
+   language. */
+:root[data-theme-preset="anthropic"] {
+  --font-sans: "Poppins", "Avenir Next", "Segoe UI", Arial, sans-serif;
+  --font-brand-body: var(--font-sans);
+  --font-brand-display: "Lora", Georgia, serif;
+  --accent: #d97757;
+  --accent-primary: #d97757;
+  --accent-secondary: #788c5d;
+  --accent-color: #d97757;
+  --accent-orange: #d97757;
+  --accent-orange-bg: rgba(217, 119, 87, 0.14);
+  --accent-orange-text: #8c4533;
+  --color-primary: #d97757;
+  --color-success: #788c5d;
+  --color-error: #c35d45;
+  --success: #788c5d;
+  --warning: #b96b4f;
+  --danger: #c35d45;
+  --text-link: #4f7da8;
+  --border-focus: #d97757;
+  --surface-hover: rgba(217, 119, 87, 0.1);
+  --shadow-sm: 0 1px 2px rgba(20, 20, 19, 0.06);
+  --shadow-md: 0 8px 24px rgba(20, 20, 19, 0.12);
+  --backdrop-blur-lg: none;
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 10px;
+}
+
+:root[data-theme-preset="anthropic"][data-theme="light"] {
+  --surface-island: #faf9f5;
+  --surface-island-strong: #faf9f5;
+  --surface-island-muted: #f2f0e8;
+  --island-shadow: 0 1px 3px rgba(20, 20, 19, 0.08);
+}
+
+:root[data-theme-preset="anthropic"][data-theme="dark"] {
+  --surface-island: #1f1f1c;
+  --surface-island-strong: #1f1f1c;
+  --surface-island-muted: #191917;
+  --island-shadow: 0 1px 3px rgba(0, 0, 0, 0.28);
+}
+
+/* The outer frame is the subtle light-gray brand field, not a blue-gray app
+   shell. `!important` is needed because palette values are applied inline. */
+:root[data-theme-preset="anthropic"][data-theme="light"] {
+  --app-bg: #e8e6dc !important;
+}
+
+:root[data-theme-preset="anthropic"][data-theme="dark"] {
+  --app-bg: #141413 !important;
+}
+
+:root[data-theme-preset="anthropic"] body,
+:root[data-theme-preset="anthropic"] button,
+:root[data-theme-preset="anthropic"] input,
+:root[data-theme-preset="anthropic"] select,
+:root[data-theme-preset="anthropic"] textarea {
+  font-family: var(--app-font-family, var(--font-sans));
+}
+
+:root[data-theme-preset="anthropic"] h1,
+:root[data-theme-preset="anthropic"] h2,
+:root[data-theme-preset="anthropic"] h3,
+:root[data-theme-preset="anthropic"] h4,
+:root[data-theme-preset="anthropic"] h5,
+:root[data-theme-preset="anthropic"] h6,
+:root[data-theme-preset="anthropic"] .api-settings-title-group strong {
+  font-family: var(--font-brand-display);
+}
+
+:root[data-theme-preset="anthropic"]
+  :is(.sidebar-content-title, .header-title, .section-title,
+    .settings-item-title, .chat-empty-quick-card-title, strong) {
+  font-family: var(--font-sans);
+}
+
+:root[data-theme-preset="anthropic"] .ai-message,
+:root[data-theme-preset="anthropic"] .ai-message p,
+:root[data-theme-preset="anthropic"] .ai-message li,
+:root[data-theme-preset="anthropic"] .user-message-bubble,
+:root[data-theme-preset="anthropic"] .context-compaction-markdown,
+:root[data-theme-preset="anthropic"] .chat-empty-quick-card-desc {
+  font-family: var(--font-brand-body);
+}
+
+:root[data-theme-preset="anthropic"] .ai-message h1,
+:root[data-theme-preset="anthropic"] .ai-message h2,
+:root[data-theme-preset="anthropic"] .ai-message h3,
+:root[data-theme-preset="anthropic"] .ai-message h4,
+:root[data-theme-preset="anthropic"] .context-compaction-markdown h1,
+:root[data-theme-preset="anthropic"] .context-compaction-markdown h2,
+:root[data-theme-preset="anthropic"] .context-compaction-markdown h3,
+:root[data-theme-preset="anthropic"] .context-compaction-markdown h4 {
+  font-family: var(--font-brand-display);
+}
+
+/* Flat, warm chrome replaces the default translucent blue workspace shell. */
+:root[data-theme-preset="anthropic"] .app-shell,
+:root[data-theme-preset="anthropic"] .app-layout,
+:root[data-theme-preset="anthropic"] .top-bar {
+  background: var(--app-bg);
+}
+
+:root[data-theme-preset="anthropic"] .app-layout {
+  gap: 8px;
+  padding: 0 12px 12px;
+}
+
+:root[data-theme-preset="anthropic"] .top-bar {
+  gap: 8px;
+  height: calc(var(--header-height) + 16px);
+  min-height: calc(var(--header-height) + 16px);
+  padding: 8px 12px;
+}
+
+:root[data-theme-preset="anthropic"] .top-bar-left,
+:root[data-theme-preset="anthropic"] .top-bar-main,
+:root[data-theme-preset="anthropic"] .top-bar-right,
+:root[data-theme-preset="anthropic"] .sidebar,
+:root[data-theme-preset="anthropic"] .main-content,
+:root[data-theme-preset="anthropic"] .right-panel {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--island-shadow);
+  backdrop-filter: none;
+}
+
+:root[data-theme-preset="anthropic"] .top-bar-left,
+:root[data-theme-preset="anthropic"] .top-bar-right,
+:root[data-theme-preset="anthropic"] .sidebar,
+:root[data-theme-preset="anthropic"] .right-panel {
+  background: var(--surface-island-muted);
+}
+
+:root[data-theme-preset="anthropic"] .top-bar-main,
+:root[data-theme-preset="anthropic"] .main-content {
+  background: var(--surface-island-strong);
+}
+
+:root[data-theme-preset="anthropic"] .main-content {
+  padding: 20px 14px;
+}
+
+:root[data-theme-preset="anthropic"] .main-header,
+:root[data-theme-preset="anthropic"] .panel-tabs {
+  background: var(--surface-island-muted);
+  border-bottom: 1px solid var(--border-light);
+}
+
+/* Shared interactive states make menus, navigation, tables, and icon buttons
+   feel like the same product rather than independent component kits. */
+:root[data-theme-preset="anthropic"]
+  :is(button, input, select, textarea, [tabindex]):focus-visible {
+  outline: 2px solid var(--accent-orange);
+  outline-offset: 2px;
+}
+
+:root[data-theme-preset="anthropic"]
+  :is(.icon-btn, .nav-item, .list-item, .settings-item, .panel-tab,
+    .panel-tab-btn, .toolbar-btn, .chat-item, .codebase-panel-view-btn,
+    .file-viewer-action-btn, .git-action-btn, .browser-nav-btn):hover {
+  background: var(--accent-orange-bg);
+  color: var(--text-primary);
+}
+
+:root[data-theme-preset="anthropic"]
+  :is(.nav-item, .list-item, .settings-item, .chat-item, .panel-tab).active {
+  border-color: color-mix(in srgb, var(--accent-orange) 38%, var(--border-color));
+  background: var(--accent-orange-bg);
+  color: var(--text-primary);
+}
+
+:root[data-theme-preset="anthropic"] .settings-item.active,
+:root[data-theme-preset="anthropic"] .chat-item.active {
+  box-shadow: inset 2px 0 var(--accent-orange);
+}
+
+:root[data-theme-preset="anthropic"] .sidebar-content-header,
+:root[data-theme-preset="anthropic"] .section-header,
+:root[data-theme-preset="anthropic"] .api-settings-page-header,
+:root[data-theme-preset="anthropic"] .codebase-panel-header,
+:root[data-theme-preset="anthropic"] .file-viewer-header,
+:root[data-theme-preset="anthropic"] .git-control-header {
+  border-bottom-color: var(--border-light);
+}
+
+/* Inputs, selects, toggles and the primary action all use the orange brand
+   accent, while status colors retain the official green/blue/red roles. */
+:root[data-theme-preset="anthropic"]
+  :is(input:not([type="checkbox"]):not([type="radio"]):not([type="range"]),
+    select,
+    textarea,
+    .custom-select-trigger,
+    .model-manual-field,
+    .search-modal-input,
+    .browser-address-input,
+    .browser-find-input,
+    .git-commit-input,
+    .file-viewer-search-input,
+    .branch-create-input) {
+  border-color: var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+}
+
+:root[data-theme-preset="anthropic"]
+  :is(input:not([type="checkbox"]):not([type="radio"]):not([type="range"]),
+    select,
+    textarea,
+    .custom-select-trigger,
+    .model-manual-field,
+    .search-modal-input,
+    .browser-address-input,
+    .browser-find-input,
+    .git-commit-input,
+    .file-viewer-search-input,
+    .branch-create-input):focus {
+  border-color: var(--accent-orange);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+  outline: none;
+}
+
+:root[data-theme-preset="anthropic"] .toggle-switch input:checked + .toggle-slider,
+:root[data-theme-preset="anthropic"] .toggle-slider {
+  border-color: var(--border-subtle);
+}
+
+:root[data-theme-preset="anthropic"] .toggle-switch input:checked + .toggle-slider {
+  background: var(--accent-orange);
+}
+
+:root[data-theme-preset="anthropic"]
+  :is(.api-settings-action-btn.primary, .api-settings-form-btn.primary,
+    .model-manual-btn.primary, .project-codebase-embed-btn.primary,
+    .confirm-dialog-btn.confirm, .tool-call-user-question-submit,
+    .tool-call-plan-approval-approve, .project-sensitive-command-save,
+    .branch-create-submit-btn, .git-commit-btn.primary) {
+  border-color: var(--accent-orange);
+  background: var(--accent-orange);
+  color: #fffaf5;
+}
+
+:root[data-theme-preset="anthropic"]
+  :is(.api-settings-action-btn.primary, .api-settings-form-btn.primary,
+    .model-manual-btn.primary, .project-codebase-embed-btn.primary,
+    .confirm-dialog-btn.confirm, .tool-call-user-question-submit,
+    .tool-call-plan-approval-approve, .project-sensitive-command-save,
+    .branch-create-submit-btn, .git-commit-btn.primary):hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent-orange) 88%, var(--text-primary));
+}
+
+/* Dropdowns and dialogs are warm, opaque surfaces so text remains legible on
+   top of optional user background images. */
+:root[data-theme-preset="anthropic"]
+  :is(.top-bar-plus-dropdown, .top-bar-todo-dropdown, .plus-menu-dropdown,
+    .model-dropdown, .file-mention-popup, .chat-command-panel,
+    .custom-select-dropdown, .custom-select-dropdown-portal,
+    .browser-menu-dropdown, .branch-dropdown, .app-modal-dialog,
+    .confirm-dialog, .search-modal, .explorer-entry-context-menu) {
+  border-color: var(--border-color);
+  border-radius: var(--radius-lg);
+  background: var(--surface-island-strong);
+  box-shadow: var(--shadow-md);
+  backdrop-filter: none;
+}
+
+:root[data-theme-preset="anthropic"]
+  :is(.top-bar-plus-dropdown-item, .top-bar-todo-item, .plus-menu-item,
+    .model-dropdown-item, .custom-select-item, .browser-menu-item,
+    .branch-dropdown-item, .chat-command-item, .mention-entry,
+    .explorer-entry-context-menu-item):hover {
+  background: var(--accent-orange-bg);
+  color: var(--text-primary);
+}
+
+/* Chat is the primary surface: prose is serif, controls are sans, and the
+   input is a quiet orange-edged editor instead of a rainbow effect. */
+:root[data-theme-preset="anthropic"] .chat-empty-greeting-logo {
+  color: var(--accent-orange);
+  filter: none;
+}
+
+:root[data-theme-preset="anthropic"] .app-shell::after {
+  z-index: 0;
+}
+
+:root[data-theme-preset="anthropic"] .app-shell > .top-bar,
+:root[data-theme-preset="anthropic"] .app-shell > .app-layout {
+  position: relative;
+  z-index: 1;
+}
+
+/* The app layout follows the top bar in the DOM. Keep the top-bar stacking
+   context above it so its New Tab dropdown can extend into the layout. */
+:root[data-theme-preset="anthropic"] .app-shell > .top-bar {
+  z-index: 2;
+}
+
+:root[data-theme-preset="anthropic"] .pixel-logo.is-frozen {
+  filter: none;
+}
+
+:root[data-theme-preset="anthropic"] .pixel-logo-pixel-frost {
+  opacity: 0 !important;
+}
+
+:root[data-theme-preset="anthropic"] .chat-empty-greeting-title {
+  color: var(--text-primary);
+  font-family: var(--font-brand-display);
+  font-size: 30px;
+  line-height: 1.2;
+}
+
+:root[data-theme-preset="anthropic"] .chat-empty-quick-card {
+  border-color: var(--border-color);
+  border-radius: var(--radius-lg);
+  background: var(--surface-island-muted);
+  box-shadow: none;
+}
+
+:root[data-theme-preset="anthropic"] .chat-empty-quick-card:hover:not(:disabled),
+:root[data-theme-preset="anthropic"] .chat-empty-quick-card:focus-visible {
+  border-color: var(--accent-orange);
+  background: var(--accent-orange-bg);
+  box-shadow: none;
+}
+
+:root[data-theme-preset="anthropic"] .user-message-bubble {
+  border: 1px solid color-mix(in srgb, var(--accent-orange) 26%, var(--border-color));
+  border-radius: var(--radius-lg);
+  background: var(--accent-orange-bg);
+}
+
+:root[data-theme-preset="anthropic"] .input-box {
+  border-color: var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface-island-strong);
+  box-shadow: var(--shadow-sm);
+}
+
+:root[data-theme-preset="anthropic"] .input-box::before {
+  display: none;
+}
+
+:root[data-theme-preset="anthropic"] .input-box:focus-within {
+  border-color: var(--accent-orange);
+  box-shadow: 0 0 0 3px var(--accent-orange-bg), var(--shadow-sm);
+}
+
+:root[data-theme-preset="anthropic"] .input-field {
+  font-family: var(--font-brand-body);
+}
+
+:root[data-theme-preset="anthropic"] .chat-message-tool,
+:root[data-theme-preset="anthropic"] .context-compaction-message,
+:root[data-theme-preset="anthropic"] .context-compaction-stream,
+:root[data-theme-preset="anthropic"] .file-changes-card,
+:root[data-theme-preset="anthropic"] .tool-call-bash-terminal {
+  border-color: var(--border-color);
+  border-radius: var(--radius-lg);
+  background: var(--surface-island-muted);
+  box-shadow: none;
+}
+
+:root[data-theme-preset="anthropic"] .tool-call-status-running,
+:root[data-theme-preset="anthropic"] .tool-call-browser-pending-running,
+:root[data-theme-preset="anthropic"] .tool-call-grep-pending-running {
+  color: var(--accent-orange-text);
+  background: var(--accent-orange-bg);
+}
+
+/* Tables and code surfaces stay utilitarian, but inherit the warm panel
+   hierarchy and orange focus/selection details. */
+:root[data-theme-preset="anthropic"]
+  :is(.ai-message .code-block-wrapper, .context-compaction-markdown .code-block-wrapper,
+    .file-viewer, .diff-viewer, .git-diff-view, .terminal-container,
+    .browser-panel, .codebase-panel-table-wrap) {
+  border-color: var(--border-color);
+  background: var(--bg-primary);
+}
+
+:root[data-theme-preset="anthropic"]
+  :is(.ai-message .code-block-header, .context-compaction-markdown .code-block-header,
+    .codebase-panel-table th, .api-settings-table th, .file-changes-header) {
+  background: var(--bg-secondary);
+  border-color: var(--border-light);
+}
+
+:root[data-theme-preset="anthropic"]
+  :is(.ai-message a, .context-compaction-markdown a, .chat-fork-divider-link,
+    .codebase-sphere-tooltip-neighbor span:last-child) {
+  color: var(--accent-blue-text);
+}
+
+:root[data-theme-preset="anthropic"] ::selection {
+  background: var(--selection-bg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root[data-theme-preset="anthropic"] * {
+    transition-duration: 0.01ms !important;
   }
 }


### PR DESCRIPTION
## Summary
- add an Anthropic theme preset with localized labels and persistent preset application
- normalize SSH browser paths and ignore stale or duplicate navigation requests
- keep the empty-chat composer reachable in short windows

## Validation
- GitHub Actions Debian 12 build: pending (run from the fork; its workflow is intentionally not part of this PR)
- `git diff --check`