### PR TITLE
fix(mcp): add discover probe timeout and fall back to legacy initialize handshake for silent old-SDK servers

### DIFF
--- a/native/src/mcp/external/http.rs
+++ b/native/src/mcp/external/http.rs
@@ -49,34 +49,48 @@ impl HttpMcpClient {
         let transport: StreamableHttpClientTransport<_> =
             StreamableHttpClientTransport::from_config(transport_config);
 
-        let running = match client_info
-            .clone()
-            .serve_with_lifecycle(transport, auto_lifecycle)
-            .await
-        {
-            Ok(running) => running,
-            Err(error) if super::should_retry_with_legacy_handshake(&error) => {
+        // 旧 SDK 服务器（如 fastmcp 构建的 firecrawl-mcp）对带 `_meta` 的
+        // `server/discover` 探测会静默不响应——既不返回 JSON-RPC 错误也不
+        // 关闭连接，导致 Auto 协商无限挂起。加超时：超时视为服务器不支持
+        // 2026-07-28 无状态协议，回退 legacy initialize 握手重连。
+        const DISCOVER_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+        let auto_result = tokio::time::timeout(
+            DISCOVER_PROBE_TIMEOUT,
+            client_info
+                .clone()
+                .serve_with_lifecycle(transport, auto_lifecycle),
+        )
+        .await;
+
+        match auto_result {
+            Ok(Ok(running)) => Ok(Self { client: running }),
+            Ok(Err(error)) if super::should_retry_with_legacy_handshake(&error) => {
                 // 重建 transport 避免复用失败连接的状态,改用 legacy 握手重连。
                 match Self::connect_legacy(config).await {
-                    Ok(client) => return Ok(client),
+                    Ok(client) => Ok(client),
                     // 重试失败时保留原始 Auto 错误(含版本协商诊断信息)
-                    Err(_) => {
-                        return Err(Error::from_reason(format!(
-                            "Failed to connect external MCP HTTP server {}: {error}",
-                            config.name
-                        )))
-                    }
+                    Err(_) => Err(Error::from_reason(format!(
+                        "Failed to connect external MCP HTTP server {}: {error}",
+                        config.name
+                    ))),
                 }
             }
-            Err(error) => {
-                return Err(Error::from_reason(format!(
-                    "Failed to connect external MCP HTTP server {}: {error}",
-                    config.name
-                )))
+            Ok(Err(error)) => Err(Error::from_reason(format!(
+                "Failed to connect external MCP HTTP server {}: {error}",
+                config.name
+            ))),
+            Err(_elapsed) => {
+                // server/discover 探测超时：服务器静默不响应（如 fastmcp 构建的
+                // firecrawl-mcp），回退 legacy 握手。
+                match Self::connect_legacy(config).await {
+                    Ok(client) => Ok(client),
+                    Err(_) => Err(Error::from_reason(format!(
+                        "Failed to connect external MCP HTTP server {}: Auto negotiate timed out (no response to server/discover), legacy initialize handshake also failed",
+                        config.name
+                    ))),
+                }
             }
-        };
-
-        Ok(Self { client: running })
+        }
     }
 
     /// 旧版本回退:直接以 legacy `initialize` 握手建立连接,跳过

--- a/native/src/mcp/external/stdio.rs
+++ b/native/src/mcp/external/stdio.rs
@@ -37,13 +37,23 @@ impl StdioMcpClient {
         };
 
         let client_info = ClientInfo::default();
-        match client_info
-            .clone()
-            .serve_with_lifecycle(spawn_transport(config).await?, auto_lifecycle)
-            .await
-        {
-            Ok(running) => Ok(Self { client: running }),
-            Err(error) if super::should_retry_with_legacy_handshake(&error) => {
+
+        // 旧 SDK 服务器（如 fastmcp 构建的 firecrawl-mcp）对带 `_meta` 的
+        // `server/discover` 探测会静默不响应——既不返回 JSON-RPC 错误也不
+        // 关闭连接，导致 Auto 协商无限挂起。加超时：超时视为服务器不支持
+        // 2026-07-28 无状态协议，回退 legacy initialize 握手重连。
+        const DISCOVER_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+        let auto_result = tokio::time::timeout(
+            DISCOVER_PROBE_TIMEOUT,
+            client_info
+                .clone()
+                .serve_with_lifecycle(spawn_transport(config).await?, auto_lifecycle),
+        )
+        .await;
+
+        match auto_result {
+            Ok(Ok(running)) => Ok(Self { client: running }),
+            Ok(Err(error)) if super::should_retry_with_legacy_handshake(&error) => {
                 // 旧子进程的管道已随 transport 关闭，重新 spawn 一个，
                 // 改用 legacy 握手重连一次。
                 match Self::connect_legacy(config).await {
@@ -55,10 +65,22 @@ impl StdioMcpClient {
                     ))),
                 }
             }
-            Err(error) => Err(Error::from_reason(format!(
+            Ok(Err(error)) => Err(Error::from_reason(format!(
                 "Failed to initialize external MCP stdio server {}: {error}",
                 config.name
             ))),
+            Err(_elapsed) => {
+                // server/discover 探测超时：服务器静默不响应（如 fastmcp 构建的
+                // firecrawl-mcp）。超时的 future 被 drop 时子进程随之终止，
+                // connect_legacy 会重新 spawn 一个进程。
+                match Self::connect_legacy(config).await {
+                    Ok(client) => Ok(client),
+                    Err(_) => Err(Error::from_reason(format!(
+                        "Failed to initialize external MCP stdio server {}: Auto negotiate timed out (no response to server/discover), legacy initialize handshake also failed",
+                        config.name
+                    ))),
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## 背景

连接 fastmcp 构建的旧 SDK MCP 服务器（如 `firecrawl-mcp` 3.23.4）时，获取工具报：

```
Failed to initialize external MCP stdio server firecrawl: connection closed: discover response
```

## 根因分析（技术原理）

Snow App 使用 rmcp SDK 3.0.1（2026-07-28 规范），`ClientLifecycleMode::Auto` 的协商流程是：

1. 先发送带 `_meta` 扩展的 `server/discover` 探测（携带 `protocolVersion: 2026-07-28`）
2. 根据服务器响应决定协议版本；失败时按错误类型降级到 legacy `initialize` 握手

实测 fastmcp（firecrawl-mcp 3.23.4）对 discover 探测的行为：

| 请求格式 | fastmcp 反应 |
| --- | --- |
| `server/discover`（不带 `_meta`） | 返回 `-32601 Method not found`（SDK 可自动降级） |
| `server/discover`（带 `_meta`，rmcp 实际发送） | **静默不响应**——既不返回 JSON-RPC 错误，也不关闭连接 |

由于 rmcp 的 `receive()` 只有在子进程 stdout EOF（进程退出）时才返回 `None`，而 fastmcp 既不报错也不退出，Auto 协商会**无限挂起**，最终连接失败。

现有 `should_retry_with_legacy_handshake` 只覆盖两类失败：
- JSON-RPC 错误（`-32601` / `-32022` 之外）
- `ConnectionClosed`（连接关闭）

**不覆盖第三类：服务器静默不响应**。这是该场景救不回来的根本原因。

## 修复方案

给 Auto 协商加 **10 秒探测超时**（`tokio::time::timeout`）：

- 超时视为"服务器不支持 2026-07-28 无状态协议"（可能正在装死）
- 自动回退 legacy `initialize` 握手重连：
  - stdio：超时的 future 被 drop 后子进程随之终止，`connect_legacy` 重新 spawn 新进程
  - http：重建 transport 后走 legacy 握手
- 错误信息区分"协商超时"与"其他错误"，便于后续诊断

## 验证

- fastmcp 对带 `_meta` 的 discover 静默不响应（复现实验确认）
- fastmcp 对 legacy `initialize`（protocolVersion 2025-11-25）正常响应（实测通过）
- 修复后 firecrawl-mcp 可正常拉取 20+ 工具

## 影响

对所有旧 SDK（fastmcp / 老版 @modelcontextprotocol/sdk）构建的 MCP 服务器通用，stdio 与 HTTP 传输均已覆盖。
