### PR TITLE
fix: repair data management archive and export flows

### DIFF
--- a/native/src/storage/database.rs
+++ b/native/src/storage/database.rs
@@ -138,7 +138,7 @@ pub fn ensure_database(database_path: &Path) -> Result<()> {
 
 /// Returns true when a rusqlite error indicates the database file is
 /// physically corrupted (b-tree page corruption, invalid page numbers, etc.).
-fn is_corruption_error(error: &rusqlite::Error) -> bool {
+pub(crate) fn is_corruption_error(error: &rusqlite::Error) -> bool {
     // Check SQLite primary error code first — more reliable than string matching.
     if let rusqlite::Error::SqliteFailure(err_code, _) = error {
         match err_code.code {

--- a/native/src/storage/services/archive.rs
+++ b/native/src/storage/services/archive.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
-use std::path::Path;
-use std::time::Duration;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use napi::bindgen_prelude::*;
 use rusqlite::{params, params_from_iter, Connection, TransactionBehavior};
@@ -51,6 +52,48 @@ fn open_archive_connection(archive_path: &Path) -> rusqlite::Result<Connection> 
     connection.pragma_update(None, "journal_mode", "DELETE")?;
     connection.pragma_update(None, "synchronous", "NORMAL")?;
     Ok(connection)
+}
+
+fn initialize_archive_database(archive_path: &Path) -> rusqlite::Result<()> {
+    let connection = open_archive_connection(archive_path)?;
+    create_archive_schema(&connection)?;
+    connection.pragma_update(None, "user_version", 1)?;
+    Ok(())
+}
+
+fn archive_quarantine_path(archive_path: &Path) -> PathBuf {
+    let file_name = archive_path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("archive.db");
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or(0);
+    archive_path.with_file_name(format!(
+        "{file_name}.corrupt.{timestamp}.{}.bak",
+        std::process::id()
+    ))
+}
+
+fn quarantine_invalid_archive_database(archive_path: &Path) -> std::io::Result<Option<PathBuf>> {
+    if !archive_path.exists() {
+        return Ok(None);
+    }
+
+    let quarantine_path = archive_quarantine_path(archive_path);
+    fs::rename(archive_path, &quarantine_path)?;
+    for suffix in ["-wal", "-shm", "-journal"] {
+        let sidecar = PathBuf::from(format!("{}{suffix}", archive_path.display()));
+        if sidecar.exists() {
+            let sidecar_quarantine = PathBuf::from(format!(
+                "{}{suffix}",
+                quarantine_path.display()
+            ));
+            fs::rename(sidecar, sidecar_quarantine)?;
+        }
+    }
+    Ok(Some(quarantine_path))
 }
 
 /// 生成 `IN (?, ?, ...)` 子句占位符。
@@ -163,15 +206,32 @@ fn create_archive_schema(connection: &Connection) -> rusqlite::Result<()> {
 
 /// 确保归档冷数据库存在且结构就绪。
 pub fn ensure_archive_database(archive_path: &Path) -> Result<()> {
-    let connection = open_archive_connection(archive_path).map_err(|error| {
-        database::database_error(archive_path, "initialize archive database", error)
-    })?;
-    create_archive_schema(&connection)
-        .map_err(|error| database::database_error(archive_path, "initialize archive database", error))?;
-    connection
-        .pragma_update(None, "user_version", 1)
-        .map_err(|error| database::database_error(archive_path, "initialize archive database", error))?;
-    Ok(())
+    match initialize_archive_database(archive_path) {
+        Ok(()) => Ok(()),
+        Err(error) if database::is_corruption_error(&error) => {
+            let quarantine_path = quarantine_invalid_archive_database(archive_path)
+                .map_err(|quarantine_error| {
+                    Error::from_reason(format!(
+                        "Failed to preserve invalid archive database at '{}': {quarantine_error}; original error: {error}",
+                        archive_path.display()
+                    ))
+                })?;
+            if let Some(path) = quarantine_path {
+                eprintln!(
+                    "Snow App archive database was invalid; preserved it at '{}' and created a new archive database.",
+                    path.display()
+                );
+            }
+            initialize_archive_database(archive_path).map_err(|retry_error| {
+                database::database_error(archive_path, "initialize archive database", retry_error)
+            })
+        }
+        Err(error) => Err(database::database_error(
+            archive_path,
+            "initialize archive database",
+            error,
+        )),
+    }
 }
 
 /// 归档会话：从运行库搬移到归档冷库（含子代理级联），并清理运行库中的
@@ -915,4 +975,56 @@ pub fn delete_archived_conversations(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temporary_archive_path() -> (PathBuf, PathBuf) {
+        let directory = std::env::temp_dir().join(format!(
+            "snow-app-archive-test-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock should be after unix epoch")
+                .as_nanos()
+        ));
+        (directory.clone(), directory.join("archive.db"))
+    }
+
+    #[test]
+    fn quarantines_non_sqlite_archive_and_recreates_schema() {
+        let (directory, archive_path) = temporary_archive_path();
+        fs::create_dir_all(&directory).expect("temporary archive directory should be created");
+        fs::write(&archive_path, b"this is not a sqlite database")
+            .expect("invalid archive fixture should be written");
+
+        ensure_archive_database(&archive_path)
+            .expect("invalid archive should be quarantined and rebuilt");
+
+        let connection = Connection::open(&archive_path).expect("rebuilt archive should open");
+        let table_count: i64 = connection
+            .query_row(
+                "SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'chat_conversations'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("rebuilt archive schema should be queryable");
+        assert_eq!(table_count, 1);
+        drop(connection);
+
+        let quarantined = fs::read_dir(&directory)
+            .expect("temporary archive directory should be readable")
+            .filter_map(|entry| entry.ok())
+            .any(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("archive.db.corrupt.")
+            });
+        assert!(quarantined, "the invalid archive should be preserved");
+
+        fs::remove_dir_all(directory).expect("temporary archive directory should be removed");
+    }
 }

--- a/src/main/dataManagement/backupService.ts
+++ b/src/main/dataManagement/backupService.ts
@@ -121,9 +121,23 @@ const parseManifest = (entries: Map<string, Buffer>): BackupManifest => {
     typeof value.id !== "string" ||
     typeof value.createdAt !== "string" ||
     !Array.isArray(value.files) ||
+    value.files.length < 1 ||
     typeof value.includesArchive !== "boolean"
   ) {
     throw new Error("Unsupported or incomplete backup manifest");
+  }
+  for (const file of value.files) {
+    if (
+      !file ||
+      typeof file.path !== "string" ||
+      !file.path ||
+      REDACTED_FILE_NAME.test(file.path) ||
+      !/^[a-f0-9]{64}$/.test(file.sha256) ||
+      !Number.isSafeInteger(file.sizeBytes) ||
+      file.sizeBytes < 0
+    ) {
+      throw new Error("Backup manifest file metadata is invalid");
+    }
   }
   return value as BackupManifest;
 };
@@ -152,6 +166,16 @@ const readAndValidateBackup = (
   }
   if (!entries.has(MAIN_ENTRY)) {
     throw new Error("Backup does not contain the main database");
+  }
+  const manifestPaths = new Set(manifest.files.map((file) => file.path));
+  if (!manifestPaths.has(MAIN_ENTRY)) {
+    throw new Error("Backup manifest does not declare the main database");
+  }
+  if (
+    manifest.includesArchive !== manifestPaths.has(ARCHIVE_ENTRY) ||
+    manifest.includesArchive !== entries.has(ARCHIVE_ENTRY)
+  ) {
+    throw new Error("Backup archive scope does not match its entries");
   }
   return { manifest, entries };
 };
@@ -211,6 +235,7 @@ export const createDatabaseBackup = async (
   const archivePath = join(stagingDirectory, "archive.db");
   const id = randomUUID();
   const createdAt = new Date().toISOString();
+  let temporaryPath: string | null = null;
   try {
     const info = await native.createDatabaseOnlineBackup(
       mainPath,
@@ -245,12 +270,23 @@ export const createDatabaseBackup = async (
       data: Buffer.from(JSON.stringify(manifest, null, 2), "utf8"),
     });
     const targetPath = join(directory, `${createdAt.replace(/[:.]/g, "-")}-${id}${BACKUP_EXTENSION}`);
-    const temporaryPath = `${targetPath}.${process.pid}.tmp`;
+    temporaryPath = `${targetPath}.${process.pid}.tmp`;
     writeFileSync(temporaryPath, createZipArchive(entries), { mode: 0o600 });
     renameSync(temporaryPath, targetPath);
+    temporaryPath = null;
+    let validatedManifest: BackupManifest;
+    try {
+      ({ manifest: validatedManifest } = readAndValidateBackup(targetPath));
+    } catch (error) {
+      rmSync(targetPath, { force: true });
+      throw new Error(
+        `Created backup package failed validation: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
     pruneBackups(directory, backupSettings().retentionCount);
-    return recordFromManifest(targetPath, manifest, "valid");
+    return recordFromManifest(targetPath, validatedManifest, "valid");
   } finally {
+    if (temporaryPath) rmSync(temporaryPath, { force: true });
     rmSync(stagingDirectory, { recursive: true, force: true });
   }
 };

--- a/src/main/ipc/handlers/dataManagementHandlers.ts
+++ b/src/main/ipc/handlers/dataManagementHandlers.ts
@@ -328,17 +328,21 @@ export const registerDataManagementHandlers = (native: NativeBridge): void => {
     });
   });
 
-  ipcMain.handle("backup:create", async (_event, reason: unknown) =>
-    dataManagementCoordinator.run("backup-create", async ({ report }) => {
+  ipcMain.handle("backup:create", async (_event, reason: unknown, includeArchiveValue: unknown) => {
+    if (includeArchiveValue !== undefined && typeof includeArchiveValue !== "boolean") {
+      throw new Error("Backup archive option must be a boolean");
+    }
+    return dataManagementCoordinator.run("backup-create", async ({ report }) => {
       report({ phase: "creating SQLite online backup", total: 3, completed: 1 });
       const record = await createDatabaseBackup(
         native,
-        typeof reason === "string" ? reason : "manual"
+        typeof reason === "string" ? reason : "manual",
+        includeArchiveValue ?? getDataManagementSettings().backup.includeArchive
       );
       report({ phase: "backup validated", total: 3, completed: 3, currentItem: record.path });
       return record;
-    })
-  );
+    });
+  });
 
   ipcMain.handle("backup:delete", (_event, value: unknown) => {
     if (typeof value !== "string" || !value) throw new Error("Backup path is required");

--- a/src/preload/modules/dataManagementApi.ts
+++ b/src/preload/modules/dataManagementApi.ts
@@ -53,8 +53,11 @@ export const dataManagementApi = {
   ): Promise<DataManagementImportPreview | null> =>
     ipcRenderer.invoke("data:apply-import", request),
 
-  createDataManagementBackup: (reason?: string): Promise<unknown | null> =>
-    ipcRenderer.invoke("backup:create", reason),
+  createDataManagementBackup: (
+    reason?: string,
+    includeArchive?: boolean
+  ): Promise<unknown | null> =>
+    ipcRenderer.invoke("backup:create", reason, includeArchive),
 
   deleteDataManagementBackup: (path: string): Promise<boolean> =>
     ipcRenderer.invoke("backup:delete", path),

--- a/src/renderer/components/sidebar/dataManagement/BackupRestoreTab.tsx
+++ b/src/renderer/components/sidebar/dataManagement/BackupRestoreTab.tsx
@@ -14,7 +14,7 @@ type BackupRestoreTabProps = {
   state: DataManagementState | null;
   settings: DataManagementSettings | null;
   onUpdateSettings: (patch: DataManagementSettingsPatch) => Promise<void>;
-  onCreate: (reason?: string) => Promise<unknown | null>;
+  onCreate: (reason?: string, includeArchive?: boolean) => Promise<unknown | null>;
   onRestore: (path: string) => Promise<boolean>;
   onDelete: (path: string) => Promise<boolean>;
 };
@@ -114,7 +114,7 @@ export function BackupRestoreTab({
   const create = async (): Promise<void> => {
     setBusy(true);
     try {
-      await onCreate("manual");
+      await onCreate("manual", includeArchive);
     } finally {
       setBusy(false);
     }

--- a/src/renderer/components/sidebar/dataManagement/ImportExportTab.tsx
+++ b/src/renderer/components/sidebar/dataManagement/ImportExportTab.tsx
@@ -1,6 +1,8 @@
 import { FileDown, FileUp, LockKeyhole, ShieldCheck } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useI18n } from "../../../i18n";
+import { ConfirmDialog } from "../../common/ConfirmDialog";
+import { FormDialog } from "../../common/FormDialog";
 import {
   DATA_MANAGEMENT_FORMAT_VERSION,
   DATA_SECTIONS,
@@ -17,6 +19,13 @@ type ImportExportTabProps = {
   onPreviewImport: (password?: string) => Promise<DataManagementImportPreview | null>;
   onExport: (request: DataManagementExportRequest) => Promise<DataManagementImportPreview | null>;
   onImport: (request: DataManagementImportRequest) => Promise<DataManagementImportPreview | null>;
+};
+
+type PasswordDialogMode = "export" | "import" | null;
+
+type PendingImport = {
+  preview: DataManagementImportPreview;
+  password?: string;
 };
 
 const SECTION_KEYS: Record<string, string> = {
@@ -45,18 +54,18 @@ export function ImportExportTab({
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState("");
   const [preview, setPreview] = useState<DataManagementImportPreview | null>(null);
+  const [passwordDialogMode, setPasswordDialogMode] = useState<PasswordDialogMode>(null);
+  const [password, setPassword] = useState("");
+  const [pendingImport, setPendingImport] = useState<PendingImport | null>(null);
+  const passwordInputRef = useRef<HTMLInputElement>(null);
 
-  const handleExport = async (): Promise<void> => {
-    const password = includeSecrets
-      ? window.prompt(t("settings.dataManagementExportPasswordPrompt", { defaultValue: "Set an encryption password for this export" })) ?? ""
-      : undefined;
-    if (includeSecrets && !password) return;
+  const exportPackage = async (exportPassword?: string): Promise<void> => {
     setBusy(true);
     try {
       const result = await onExport({
         sections: [...DATA_SECTIONS],
         includeSecrets,
-        password,
+        password: exportPassword,
       });
       if (result)
         setMessage(
@@ -72,52 +81,120 @@ export function ImportExportTab({
     }
   };
 
+  const handleExport = async (): Promise<void> => {
+    if (includeSecrets) {
+      setPassword("");
+      setPasswordDialogMode("export");
+      return;
+    }
+    await exportPackage();
+  };
+
+  const openImportConfirmation = (nextPendingImport: PendingImport): void => {
+    setPendingImport(nextPendingImport);
+    setPreview(nextPendingImport.preview);
+  };
+
   const handleImport = async (): Promise<void> => {
     setBusy(true);
     try {
-      let nextPreview = await onPreviewImport();
-      if (!nextPreview) return;
-      const password = nextPreview.encrypted
-        ? window.prompt(t("settings.dataManagementImportPasswordPrompt", { defaultValue: "Enter the package encryption password" })) ?? ""
-        : undefined;
-      if (nextPreview.encrypted && !password) return;
-      if (password) {
-        const decryptedPreview = await onPreviewImport(password);
-        if (!decryptedPreview) return;
-        nextPreview = decryptedPreview;
-      }
-      setPreview(nextPreview);
-      const description = t("settings.dataManagementImportDescription", {
-        values: { rows: nextPreview.rows, sections: nextPreview.sections.length },
-        defaultValue: "{{rows}} rows, {{sections}} sections",
-      });
-      if (
-        !window.confirm(
-          t("settings.dataManagementImportConfirm", {
-            values: { description },
-            defaultValue: "Import this configuration package ({{description}})?",
-          })
-        )
-      )
+      const nextPreview = await onPreviewImport();
+      if (!nextPreview) {
         return;
-      const result = await onImport({
-        sections: [...DATA_SECTIONS],
-        password,
-        replaceSelected,
-      });
-      if (result)
-        setMessage(
-          t("settings.dataManagementImportedRows", {
-            values: { rows: result.rows },
-            defaultValue: "Imported {{rows}} configuration rows",
-          })
-        );
+      }
+      if (nextPreview.encrypted) {
+        setPassword("");
+        setPendingImport({ preview: nextPreview });
+        setPasswordDialogMode("import");
+      } else {
+        openImportConfirmation({ preview: nextPreview });
+      }
     } catch {
       // The shared panel displays the error from useDataManagement.
     } finally {
       setBusy(false);
     }
   };
+
+  const submitPassword = async (): Promise<void> => {
+    if (!password || !passwordDialogMode) {
+      return;
+    }
+    const mode = passwordDialogMode;
+    const enteredPassword = password;
+    setPassword("");
+    setPasswordDialogMode(null);
+
+    if (mode === "export") {
+      await exportPackage(enteredPassword);
+      return;
+    }
+
+    setBusy(true);
+    try {
+      const decryptedPreview = await onPreviewImport(enteredPassword);
+      if (decryptedPreview) {
+        openImportConfirmation({
+          preview: decryptedPreview,
+          password: enteredPassword,
+        });
+      }
+    } catch {
+      // The shared panel displays the error from useDataManagement.
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const cancelPasswordDialog = (): void => {
+    setPassword("");
+    setPasswordDialogMode(null);
+    if (passwordDialogMode === "import") {
+      setPendingImport(null);
+    }
+  };
+
+  const cancelImportConfirmation = (): void => {
+    setPendingImport(null);
+  };
+
+  const confirmImport = async (): Promise<void> => {
+    if (!pendingImport) {
+      return;
+    }
+    const importRequest = pendingImport;
+    setPendingImport(null);
+    setBusy(true);
+    try {
+      const result = await onImport({
+        sections: [...DATA_SECTIONS],
+        password: importRequest.password,
+        replaceSelected,
+      });
+      if (result) {
+        setMessage(
+          t("settings.dataManagementImportedRows", {
+            values: { rows: result.rows },
+            defaultValue: "Imported {{rows}} configuration rows",
+          })
+        );
+      }
+    } catch {
+      // The shared panel displays the error from useDataManagement.
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const importDescription = pendingImport
+    ? t("settings.dataManagementImportDescription", {
+        values: {
+          rows: pendingImport.preview.rows,
+          sections: pendingImport.preview.sections.length,
+        },
+        defaultValue: "{{rows}} rows, {{sections}} sections",
+      })
+    : "";
 
   return (
     <div className="data-management-tab-content">
@@ -229,6 +306,67 @@ export function ImportExportTab({
           </p>
         </section>
       )}
+
+      <FormDialog
+        open={passwordDialogMode !== null}
+        title={
+          passwordDialogMode === "export"
+            ? t("settings.dataManagementExportPasswordPrompt", {
+                defaultValue: "Set an encryption password for this export",
+              })
+            : t("settings.dataManagementImportPasswordPrompt", {
+                defaultValue: "Enter the package encryption password",
+              })
+        }
+        confirmLabel={t("common.confirm", { defaultValue: "Confirm" })}
+        cancelLabel={t("common.cancel", { defaultValue: "Cancel" })}
+        closeLabel={t("common.close", { defaultValue: "Close" })}
+        confirmDisabled={!password}
+        isSubmitting={busy}
+        initialFocusRef={passwordInputRef}
+        onConfirm={() => void submitPassword()}
+        onCancel={cancelPasswordDialog}
+      >
+        <label className="form-dialog-field">
+          <span className="form-dialog-label">
+            {passwordDialogMode === "export"
+              ? t("settings.dataManagementExportPasswordPrompt", {
+                  defaultValue: "Encryption password",
+                })
+              : t("settings.dataManagementImportPasswordPrompt", {
+                  defaultValue: "Package encryption password",
+                })}
+          </span>
+          <input
+            ref={passwordInputRef}
+            className="form-dialog-input"
+            type="password"
+            value={password}
+            maxLength={4096}
+            autoComplete="new-password"
+            onChange={(event) => setPassword(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && password) {
+                event.preventDefault();
+                void submitPassword();
+              }
+            }}
+          />
+        </label>
+      </FormDialog>
+
+      <ConfirmDialog
+        open={pendingImport !== null && passwordDialogMode === null}
+        title={t("settings.dataManagementImport", { defaultValue: "Import configuration" })}
+        message={t("settings.dataManagementImportConfirm", {
+          values: { description: importDescription },
+          defaultValue: "Import this configuration package ({{description}})?",
+        })}
+        confirmLabel={t("common.confirm", { defaultValue: "Confirm" })}
+        cancelLabel={t("common.cancel", { defaultValue: "Cancel" })}
+        onConfirm={() => void confirmImport()}
+        onCancel={cancelImportConfirmation}
+      />
 
       <section className="data-management-card data-management-security-card">
         <div className="data-management-card-heading">

--- a/src/renderer/components/sidebar/dataManagement/useDataManagement.ts
+++ b/src/renderer/components/sidebar/dataManagement/useDataManagement.ts
@@ -21,7 +21,7 @@ export type UseDataManagementResult = {
   previewImport: (password?: string) => Promise<DataManagementImportPreview | null>;
   exportConfig: (request: DataManagementExportRequest) => Promise<DataManagementImportPreview | null>;
   importConfig: (request: DataManagementImportRequest) => Promise<DataManagementImportPreview | null>;
-  createBackup: (reason?: string) => Promise<unknown | null>;
+  createBackup: (reason?: string, includeArchive?: boolean) => Promise<unknown | null>;
   restoreBackup: (path: string) => Promise<boolean>;
   deleteBackup: (path: string) => Promise<boolean>;
   testSync: () => Promise<{ weakConflictProtection: boolean }>;
@@ -112,7 +112,8 @@ export const useDataManagement = (): UseDataManagementResult => {
     previewImport: (password) => action(() => window.snow.previewDataManagementImport(password)),
     exportConfig: (request) => action(() => window.snow.exportDataManagementConfig(request)),
     importConfig: (request) => action(() => window.snow.importDataManagementConfig(request)),
-    createBackup: (reason) => action(() => window.snow.createDataManagementBackup(reason)),
+    createBackup: (reason, includeArchive) =>
+      action(() => window.snow.createDataManagementBackup(reason, includeArchive)),
     restoreBackup: (path) => action(() => window.snow.restoreDataManagementBackup(path)),
     deleteBackup: (path) => action(() => window.snow.deleteDataManagementBackup(path)),
     testSync: () => action(() => window.snow.testDataManagementSyncConnection()),


### PR DESCRIPTION
## Summary

This PR fixes several data-management failures discovered after the previous implementation was merged.

### Fixed issues

* Encrypted configuration export appeared to do nothing because it relied on browser `prompt`/`confirm` APIs that are not reliable in the Electron renderer. Password input and confirmation now use the application's native dialogs.
* Snapshot creation and full database mirror failed when `archive.db` was not a valid SQLite database.
* Manual snapshots could use a stale `include archive.db` setting because the checkbox update was asynchronous.
* Newly created snapshot packages could be reported as `unknown · invalid` after being reloaded.

## Changes

### Encrypted configuration export/import

* Replaced `window.prompt` and `window.confirm` with application-native form and confirmation dialogs.
* Added visible password validation and confirmation flow for encrypted configuration packages.
* Preserved the existing error reporting through the shared data-management task panel.

### Archive database recovery

* Detect invalid or corrupted `archive.db` files, including SQLite `NotADatabase` and corruption errors.

* Preserve the original file as:

  `archive.db.corrupt.<timestamp>.<process-id>.bak`

* Preserve related SQLite sidecar files when present.

* Recreate a valid archive database and initialize the expected archive schema.

* This allows snapshots and full database mirrors to continue without silently deleting the original file.

### Snapshot and WebDAV mirror reliability

* Pass the current `include archive.db` selection explicitly through the renderer, preload, IPC, and backup service layers.
* Validate the generated `.snowbackup` package after the atomic rename.
* Validate manifest metadata, SHA-256 checksums, main database presence, archive scope, and archive entry consistency.
* Invalid packages created during a failed backup are removed instead of being returned as valid records.

## Verification

* `npm run check:ts`
* `npm run test:ts` — 31 tests passed
* `./node_modules/.bin/electron-vite build`
* `node scripts/check-docs.cjs`
* `git diff --check`

A Rust regression test was added for quarantining and rebuilding a non-SQLite archive database. 