### PR TITLE
fix(gemini): preserve MCP tool results and recover duplicate reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,9 @@ scripts/e2e-verify-config.cjs
 .trellis/
 .codex/
 .agents/
+.agent/
 AGENTS.md
+GEMINI.md
 .ace-tool/
 .codex-user-data/
 design-qa.md

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ scripts/e2e-verify-config.cjs
 
 # Local AI workflow tooling (excluded per user request)
 .trellis/
+.codex/
+.agents/
 AGENTS.md
 .ace-tool/
 .codex-user-data/

--- a/native/src/api/anthropic/mod.rs
+++ b/native/src/api/anthropic/mod.rs
@@ -135,7 +135,10 @@ async fn create_anthropic_response_async(
     )
     .await?;
 
-    let tools = if request.context_compaction.unwrap_or(false) || skip_context {
+    let tools = if request.context_compaction.unwrap_or(false)
+        || skip_context
+        || request.disable_tools.unwrap_or(false)
+    {
         None
     } else {
         match resolve_sub_agent_tools(&request).await {

--- a/native/src/api/anthropic/payload.rs
+++ b/native/src/api/anthropic/payload.rs
@@ -342,11 +342,19 @@ pub(super) fn build_anthropic_payload(
     // cache_control on the last block). Otherwise the built-in system
     // prompt parts are used. A plain string system field cannot carry
     // cache_control, so we always emit an array of text blocks.
-    let system_parts: Vec<&String> = if has_user_system_prompts {
-        user_system_prompts.iter().collect()
+    let mut system_parts: Vec<String> = if has_user_system_prompts {
+        user_system_prompts.to_vec()
     } else {
-        builtin_system_parts.iter().collect()
+        builtin_system_parts
     };
+    if let Some(prompt) = request
+        .internal_recovery_prompt
+        .as_deref()
+        .map(str::trim)
+        .filter(|prompt| !prompt.is_empty())
+    {
+        system_parts.push(prompt.to_string());
+    }
 
     if !system_parts.is_empty() {
         let system_blocks: Vec<Value> = system_parts

--- a/native/src/api/chat/mod.rs
+++ b/native/src/api/chat/mod.rs
@@ -134,7 +134,10 @@ async fn create_chat_completion_response_async(
     let client = crate::api::http_client::build_proxied_client()
         .await
         .map_err(|error| Error::from_reason(format!("Failed to create HTTP client: {}", error)))?;
-    let tools = if request.context_compaction.unwrap_or(false) || skip_context {
+    let tools = if request.context_compaction.unwrap_or(false)
+        || skip_context
+        || request.disable_tools.unwrap_or(false)
+    {
         None
     } else {
         match resolve_sub_agent_tools(&request).await {

--- a/native/src/api/chat/payload.rs
+++ b/native/src/api/chat/payload.rs
@@ -222,11 +222,24 @@ pub(super) fn build_chat_completions_payload(
     // When user system prompts are present, emit them as a single `system`
     // message with multiple content blocks and demote the built-in prompt
     // to a leading `user` message (Snow CLI PR #127).
-    if has_user_system_prompts {
-        let user_prompt_blocks: Vec<Value> = user_system_prompts
+    if has_user_system_prompts
+        || request
+            .internal_recovery_prompt
+            .as_deref()
+            .is_some_and(|prompt| !prompt.trim().is_empty())
+    {
+        let mut user_prompt_blocks: Vec<Value> = user_system_prompts
             .iter()
             .map(|text| json!({ "type": "text", "text": text }))
             .collect();
+        if let Some(prompt) = request
+            .internal_recovery_prompt
+            .as_deref()
+            .map(str::trim)
+            .filter(|prompt| !prompt.is_empty())
+        {
+            user_prompt_blocks.push(json!({ "type": "text", "text": prompt }));
+        }
         let system_message = json!({
             "role": "system",
             "content": user_prompt_blocks,

--- a/native/src/api/codebase_review.rs
+++ b/native/src/api/codebase_review.rs
@@ -287,7 +287,7 @@ async fn review_results(query: &str, results: &[SearchResult]) -> Result<ReviewO
             )
             .await?
         }
-        "gemini" => {
+        "gemini" | "interactions" => {
             review_via_gemini(
                 &api_config,
                 &api_key,

--- a/native/src/api/commit_message.rs
+++ b/native/src/api/commit_message.rs
@@ -65,6 +65,8 @@ fn build_request(staged_diff: &str) -> ResponsesApiRequest {
         sub_agent_system_prompt: None,
         sub_agent_config_profile: None,
         skip_context: Some(true),
+        disable_tools: None,
+        internal_recovery_prompt: None,
         plan_mode: None,
         goal_mode: None,
         worktree_mode: None,

--- a/native/src/api/commit_message.rs
+++ b/native/src/api/commit_message.rs
@@ -188,8 +188,19 @@ pub async fn generate_commit_message_stream(
             )
             .await
         }
+        "interactions" => {
+            crate::api::interactions::create_interactions_response_stream(
+                request,
+                database_path,
+                api_config,
+                custom_headers,
+                on_chunk,
+                cancel_token,
+            )
+            .await
+        }
         request_method => Err(Error::from_reason(format!(
-            "Unsupported request method '{}'. Please switch the active API request method to Chat, Responses, Anthropic or Gemini.",
+            "Unsupported request method '{}'. Please switch the active API request method to Chat, Responses, Anthropic, Gemini, or Interactions.",
             request_method
         ))),
     };

--- a/native/src/api/conversation/context.rs
+++ b/native/src/api/conversation/context.rs
@@ -5,16 +5,16 @@ use napi::bindgen_prelude::*;
 
 use crate::prompt::goal_mode_system_prompt::build_goal_mode_system_prompt;
 use crate::prompt::plan_mode_system_prompt::build_plan_mode_system_prompt;
-use crate::prompt::worktree_mode_system_prompt::build_worktree_mode_system_prompt;
 use crate::prompt::system_prompt::build_system_prompt;
+use crate::prompt::worktree_mode_system_prompt::build_worktree_mode_system_prompt;
 use crate::storage::services::chat_conversations::{
     get_conversation_modes, load_context_messages, resolve_conversation_id, ChatContextMessage,
 };
 use crate::storage::services::sub_agent_configs::list_sub_agent_configs;
-use crate::storage::SubAgentConfigRecord;
 use crate::storage::services::system_prompts::resolve_active_system_prompt_contents;
 use crate::storage::services::system_settings::get_system_setting_value;
 use crate::storage::services::workspace_directories::get_workspace_directory_path;
+use crate::storage::SubAgentConfigRecord;
 
 use super::tool_messages::ensure_tool_pairing;
 use super::{images::persist_inline_images_to_disk, ConversationContextRequest};
@@ -101,11 +101,7 @@ fn build_sub_agents_section(database_path: &Path, directory_id: Option<&str>) ->
                 if !seen.insert(config.agent_id.as_str()) {
                     continue;
                 }
-                let mut line = format!(
-                    "- `{}` — {}",
-                    config.agent_id.trim(),
-                    config.name.trim()
-                );
+                let mut line = format!("- `{}` — {}", config.agent_id.trim(), config.name.trim());
                 if !config.description.trim().is_empty() {
                     line.push_str(&format!(": {}", config.description.trim()));
                 }
@@ -348,12 +344,24 @@ fn normalize_messages(messages: &[ChatContextMessage]) -> Vec<ChatContextMessage
         .iter()
         .filter_map(|message| {
             let content = message.content.trim();
-            if content.is_empty() {
+            let role = message.role.trim();
+            let has_structured_tool_data = match role {
+                "assistant" => message
+                    .tool_calls_json
+                    .as_deref()
+                    .is_some_and(has_json_entries),
+                "tool" => message
+                    .tool_results_json
+                    .as_deref()
+                    .is_some_and(has_json_entries),
+                _ => false,
+            };
+            if content.is_empty() && !has_structured_tool_data {
                 return None;
             }
 
             Some(ChatContextMessage {
-                role: message.role.trim().to_string(),
+                role: role.to_string(),
                 content: content.to_string(),
                 tool_calls_json: message.tool_calls_json.clone(),
                 tool_results_json: message.tool_results_json.clone(),
@@ -362,6 +370,13 @@ fn normalize_messages(messages: &[ChatContextMessage]) -> Vec<ChatContextMessage
             })
         })
         .collect()
+}
+
+fn has_json_entries(raw: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(raw)
+        .ok()
+        .and_then(|value| value.as_array().map(|entries| !entries.is_empty()))
+        .unwrap_or(false)
 }
 
 /// Read the user's configured default shell type from the terminal settings
@@ -393,3 +408,46 @@ fn resolve_default_shell(database_path: &std::path::Path) -> String {
     crate::exports::terminal::detect_shell_family(&shell_path)
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn message(
+        role: &str,
+        content: &str,
+        tool_calls_json: Option<&str>,
+        tool_results_json: Option<&str>,
+    ) -> ChatContextMessage {
+        ChatContextMessage {
+            role: role.to_string(),
+            content: content.to_string(),
+            tool_calls_json: tool_calls_json.map(str::to_string),
+            tool_results_json: tool_results_json.map(str::to_string),
+            thinking: None,
+            thinking_blocks_json: None,
+        }
+    }
+
+    #[test]
+    fn normalize_messages_keeps_empty_structured_tool_messages() {
+        let normalized = normalize_messages(&[
+            message("assistant", "", Some(r#"[{"id":"call-1"}]"#), None),
+            message("tool", "", None, Some(r#"[{"callId":"call-1"}]"#)),
+        ]);
+
+        assert_eq!(normalized.len(), 2);
+        assert_eq!(normalized[0].role, "assistant");
+        assert_eq!(normalized[1].role, "tool");
+    }
+
+    #[test]
+    fn normalize_messages_drops_empty_or_malformed_structured_messages() {
+        let normalized = normalize_messages(&[
+            message("assistant", "", Some("[]"), None),
+            message("tool", "", None, Some("not-json")),
+            message("user", "", None, None),
+        ]);
+
+        assert!(normalized.is_empty());
+    }
+}

--- a/native/src/api/conversation/stream.rs
+++ b/native/src/api/conversation/stream.rs
@@ -9,6 +9,7 @@ use crate::api::config::{
     resolve_advanced_model,
 };
 use crate::api::gemini::create_gemini_response_stream;
+use crate::api::interactions::create_interactions_response_stream;
 use crate::api::responses::{
     create_response_stream_with_context, ResponsesApiRequest, ResponsesApiResult,
     ResponsesApiStreamCallback,
@@ -295,8 +296,19 @@ pub async fn create_response_stream(
             )
             .await
         }
+        "interactions" => {
+            create_interactions_response_stream(
+                request,
+                context.database_path,
+                api_config,
+                context.custom_headers,
+                on_chunk,
+                cancel_token.clone(),
+            )
+            .await
+        }
         request_method => Err(Error::from_reason(format!(
-            "Unsupported chat request method '{}'. Please switch the active API request method to Chat, Responses, Anthropic or Gemini.",
+            "Unsupported chat request method '{}'. Please switch the active API request method to Chat, Responses, Anthropic, Gemini, or Interactions.",
             request_method
         ))),
     };

--- a/native/src/api/conversation/tool_messages.rs
+++ b/native/src/api/conversation/tool_messages.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::path::Path;
 
 use serde_json::Value;
@@ -14,7 +14,7 @@ use crate::storage::services::chat_conversations::ChatContextMessage;
 /// - **OpenAI Chat**: `{"id":"...","type":"function","function":{"name":"...","arguments":"..."}}`
 /// - **OpenAI Responses**: `{"type":"function_call","call_id":"...","name":"...","arguments":"..."}`
 /// - **Anthropic**: `{"type":"tool_use","id":"...","name":"...","input":{...}}`
-/// - **Gemini**: `{"functionCall":{"name":"...","args":{...}}}`
+/// - **Gemini**: `{"functionCall":{"id":"...","name":"...","args":{...}}}`
 pub fn tool_calls_as_anthropic_blocks(tool_calls_json: &str) -> Vec<Value> {
     normalize_tool_calls(tool_calls_json)
         .into_iter()
@@ -35,12 +35,13 @@ pub fn tool_calls_as_gemini_parts(tool_calls_json: &str) -> Vec<Value> {
     normalize_tool_calls(tool_calls_json)
         .into_iter()
         .map(|entry| {
-            serde_json::json!({
-                "functionCall": {
-                    "name": entry.name,
-                    "args": entry.input,
-                }
-            })
+            let mut function_call = serde_json::Map::new();
+            if !entry.id.is_empty() {
+                function_call.insert("id".to_string(), Value::String(entry.id));
+            }
+            function_call.insert("name".to_string(), Value::String(entry.name));
+            function_call.insert("args".to_string(), entry.input);
+            serde_json::json!({ "functionCall": function_call })
         })
         .collect()
 }
@@ -192,7 +193,7 @@ pub(crate) struct NormalizedToolCall {
 /// - **OpenAI Chat**: `{"id":"...","type":"function","function":{"name":"...","arguments":"..."}}`
 /// - **OpenAI Responses**: `{"type":"function_call","call_id":"...","name":"...","arguments":"..."}`
 /// - **Anthropic**: `{"type":"tool_use","id":"...","name":"...","input":{...}}`
-/// - **Gemini**: `{"functionCall":{"name":"...","args":{...}}}`
+/// - **Gemini**: `{"functionCall":{"id":"...","name":"...","args":{...}}}`
 pub(crate) fn normalize_tool_calls(tool_calls_json: &str) -> Vec<NormalizedToolCall> {
     let Ok(parsed) = serde_json::from_str::<Value>(tool_calls_json) else {
         return Vec::new();
@@ -212,7 +213,13 @@ pub(crate) fn normalize_tool_calls(tool_calls_json: &str) -> Vec<NormalizedToolC
             let id = call
                 .get("call_id")
                 .and_then(Value::as_str)
-                .or_else(|| call.get("id").and_then(Value::as_str))?
+                .or_else(|| call.get("id").and_then(Value::as_str))
+                .or_else(|| {
+                    call.get("functionCall")
+                        .and_then(|function_call| function_call.get("id"))
+                        .and_then(Value::as_str)
+                })
+                .unwrap_or("")
                 .to_string();
             if id.is_empty() {
                 return None;
@@ -307,6 +314,124 @@ pub fn extract_tool_call_entries(tool_calls_json: &str) -> Vec<(String, String)>
         .collect()
 }
 
+/// Remove persisted calls which are syntactically JSON objects but cannot be
+/// executed by Snow's built-in tools. This works on an outbound context copy;
+/// it deliberately never changes the stored conversation.
+///
+/// A malformed upstream functionCall must not be replayed with its parameter
+/// error result, otherwise Gemini-compatible relays can repeatedly emit the
+/// same empty call. This list is intentionally limited to Snow-owned tools
+/// whose required fields are stable. Parameterless and third-party MCP tools
+/// remain untouched.
+pub fn remove_invalid_snow_tool_calls(messages: &mut [ChatContextMessage]) {
+    let mut invalid_call_ids = HashSet::new();
+    // Gemini's native functionCall does not carry an id. Retain the call
+    // order so an id-less functionResponse can be removed with its invalid
+    // call without accidentally removing a preceding valid call of the same
+    // name.
+    let mut idless_call_removals: VecDeque<(String, bool)> = VecDeque::new();
+
+    for message in messages.iter_mut() {
+        match message.role.trim() {
+            "assistant" => {
+                let Some(raw) = message.tool_calls_json.as_deref() else {
+                    continue;
+                };
+                let Ok(Value::Array(calls)) = serde_json::from_str::<Value>(raw) else {
+                    continue;
+                };
+                let normalized = normalize_tool_calls(raw);
+                let filtered: Vec<Value> = calls
+                    .into_iter()
+                    .enumerate()
+                    .filter_map(|(index, call)| {
+                        let Some(entry) = normalized.get(index) else {
+                            return Some(call);
+                        };
+                        let is_valid = snow_tool_call_has_required_arguments(entry);
+                        let id = extract_call_id_from_json(&call);
+                        if id.is_empty() {
+                            idless_call_removals.push_back((entry.name.clone(), !is_valid));
+                        } else if !is_valid {
+                            invalid_call_ids.insert(id);
+                        }
+                        is_valid.then_some(call)
+                    })
+                    .collect();
+                message.tool_calls_json = (!filtered.is_empty())
+                    .then(|| serde_json::to_string(&filtered).ok())
+                    .flatten();
+            }
+            "tool" => {
+                let Some(raw) = message.tool_results_json.as_deref() else {
+                    continue;
+                };
+                let Ok(Value::Array(results)) = serde_json::from_str::<Value>(raw) else {
+                    continue;
+                };
+                let filtered: Vec<Value> = results
+                    .into_iter()
+                    .filter(|result| {
+                        let call_id = extract_result_call_id_from_json(result);
+                        if !call_id.is_empty() {
+                            return !invalid_call_ids.contains(&call_id);
+                        }
+
+                        let Some(result_name) = result.get("name").and_then(Value::as_str) else {
+                            return true;
+                        };
+                        let Some((call_name, remove_result)) = idless_call_removals.front() else {
+                            return true;
+                        };
+                        if call_name != result_name {
+                            return true;
+                        }
+                        let remove_result = *remove_result;
+                        idless_call_removals.pop_front();
+                        !remove_result
+                    })
+                    .collect();
+                message.tool_results_json = (!filtered.is_empty())
+                    .then(|| serde_json::to_string(&filtered).ok())
+                    .flatten();
+            }
+            _ => {}
+        }
+    }
+}
+
+fn snow_tool_call_has_required_arguments(entry: &NormalizedToolCall) -> bool {
+    let required_strings: &[&str] = match entry.name.as_str() {
+        "filesystem-read" => &["filePath"],
+        "filesystem-create" => &["filePath", "content"],
+        "filesystem-replace_edit" => &["filePath", "searchContent", "replaceContent"],
+        "bash-terminal-execute" => &["command"],
+        _ => return true,
+    };
+    if !entry.has_valid_name || !entry.has_valid_input {
+        return false;
+    }
+    let Some(input) = entry.input.as_object() else {
+        return false;
+    };
+    required_strings.iter().all(|key| {
+        input
+            .get(*key)
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    }) && (entry.name != "filesystem-create"
+        || input.get("overwrite").is_some_and(Value::is_boolean))
+}
+
+fn extract_result_call_id_from_json(result: &Value) -> String {
+    result
+        .get("callId")
+        .and_then(Value::as_str)
+        .or_else(|| result.get("call_id").and_then(Value::as_str))
+        .unwrap_or("")
+        .to_string()
+}
+
 /// Extract the call ID from a single tool call JSON value.
 ///
 /// Prioritizes `call_id` (Responses API format) over `id` (Chat Completions
@@ -316,6 +441,11 @@ fn extract_call_id_from_json(call: &Value) -> String {
     call.get("call_id")
         .and_then(Value::as_str)
         .or_else(|| call.get("id").and_then(Value::as_str))
+        .or_else(|| {
+            call.get("functionCall")
+                .and_then(|function_call| function_call.get("id"))
+                .and_then(Value::as_str)
+        })
         .unwrap_or("")
         .to_string()
 }
@@ -468,5 +598,156 @@ pub fn ensure_tool_pairing(messages: &mut Vec<ChatContextMessage>) {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn message(role: &str, calls: Option<&str>, results: Option<&str>) -> ChatContextMessage {
+        ChatContextMessage {
+            role: role.to_string(),
+            content: "tool context".to_string(),
+            tool_calls_json: calls.map(str::to_string),
+            tool_results_json: results.map(str::to_string),
+            thinking: None,
+            thinking_blocks_json: None,
+        }
+    }
+
+    #[test]
+    fn removes_empty_builtin_call_and_its_result() {
+        let mut messages = vec![
+            message(
+                "assistant",
+                Some(
+                    r#"[{"id":"bad","functionCall":{"name":"filesystem-read","args":{}}},{"id":"good","functionCall":{"name":"filesystem-read","args":{"filePath":"package.json"}}}]"#,
+                ),
+                None,
+            ),
+            message(
+                "tool",
+                None,
+                Some(
+                    r#"[{"name":"filesystem-read","callId":"bad","result":"filePath is required"},{"name":"filesystem-read","callId":"good","result":"{}"}]"#,
+                ),
+            ),
+        ];
+
+        remove_invalid_snow_tool_calls(&mut messages);
+
+        assert_eq!(
+            extract_tool_call_entries(messages[0].tool_calls_json.as_deref().unwrap()),
+            vec![("good".to_string(), "filesystem-read".to_string())]
+        );
+        assert_eq!(
+            parse_tool_results_json(messages[1].tool_results_json.as_deref().unwrap()),
+            vec![(
+                "filesystem-read".to_string(),
+                "good".to_string(),
+                "{}".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn preserves_parameterless_third_party_tool() {
+        let mut messages = vec![message(
+            "assistant",
+            Some(r#"[{"id":"search","functionCall":{"name":"server-search","args":{}}}]"#),
+            None,
+        )];
+
+        remove_invalid_snow_tool_calls(&mut messages);
+
+        assert!(messages[0].tool_calls_json.is_some());
+    }
+
+    #[test]
+    fn removes_idless_invalid_gemini_call_and_only_its_ordered_result() {
+        let mut messages = vec![
+            message(
+                "assistant",
+                Some(
+                    r#"[{"functionCall":{"name":"filesystem-read","args":{"filePath":"README.md"}}},{"functionCall":{"name":"filesystem-read","args":{}}}]"#,
+                ),
+                None,
+            ),
+            message(
+                "tool",
+                None,
+                Some(
+                    r#"[{"name":"filesystem-read","result":"README"},{"name":"filesystem-read","result":"filePath is required"}]"#,
+                ),
+            ),
+        ];
+
+        remove_invalid_snow_tool_calls(&mut messages);
+
+        assert_eq!(
+            extract_tool_call_entries(messages[0].tool_calls_json.as_deref().unwrap()),
+            vec![(String::new(), "filesystem-read".to_string())]
+        );
+        let results: Vec<Value> =
+            serde_json::from_str(messages[1].tool_results_json.as_deref().unwrap()).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["result"], "README");
+    }
+
+    #[test]
+    fn preserves_nested_gemini_function_call_id_when_replaying_history() {
+        let raw = r#"[{"functionCall":{"id":"gemini-call-1","name":"filesystem-read","args":{"filePath":"package.json"}}}]"#;
+
+        assert_eq!(
+            extract_tool_call_entries(raw),
+            vec![("gemini-call-1".to_string(), "filesystem-read".to_string())]
+        );
+        assert_eq!(
+            tool_calls_as_gemini_parts(raw),
+            vec![serde_json::json!({
+                "functionCall": {
+                    "id": "gemini-call-1",
+                    "name": "filesystem-read",
+                    "args": { "filePath": "package.json" },
+                }
+            })]
+        );
+    }
+
+    #[test]
+    fn pairing_keeps_nested_gemini_call_id_with_matching_result() {
+        let mut messages = vec![
+            message(
+                "assistant",
+                Some(
+                    r#"[{"functionCall":{"id":"gemini-call-1","name":"filesystem-read","args":{"filePath":"package.json"}}}]"#,
+                ),
+                None,
+            ),
+            message(
+                "tool",
+                None,
+                Some(
+                    r#"[{"name":"filesystem-read","callId":"gemini-call-1","result":"package content"}]"#,
+                ),
+            ),
+        ];
+
+        ensure_tool_pairing(&mut messages);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(
+            extract_tool_call_entries(messages[0].tool_calls_json.as_deref().unwrap()),
+            vec![("gemini-call-1".to_string(), "filesystem-read".to_string())]
+        );
+        assert_eq!(
+            parse_tool_results_json(messages[1].tool_results_json.as_deref().unwrap()),
+            vec![(
+                "filesystem-read".to_string(),
+                "gemini-call-1".to_string(),
+                "package content".to_string(),
+            )]
+        );
     }
 }

--- a/native/src/api/conversation/tool_messages.rs
+++ b/native/src/api/conversation/tool_messages.rs
@@ -78,26 +78,35 @@ pub fn tool_calls_as_chat_completions(tool_calls_json: &str) -> Vec<Value> {
 
 /// Parse tool_results_json into (name, callId, result) tuples.
 pub fn parse_tool_results_json(raw: &str) -> Vec<(String, String, String)> {
+    parse_tool_result_records(raw)
+        .into_iter()
+        .map(|record| (record.name, record.call_id, record.result))
+        .collect()
+}
+
+struct ToolResultRecord {
+    name: String,
+    call_id: String,
+    result: String,
+    has_valid_shape: bool,
+}
+
+fn parse_tool_result_records(raw: &str) -> Vec<ToolResultRecord> {
     serde_json::from_str::<Vec<Value>>(raw)
         .unwrap_or_default()
         .into_iter()
         .map(|v| {
-            let name = v
-                .get("name")
-                .and_then(|x| x.as_str())
-                .unwrap_or("")
-                .to_string();
-            let call_id = v
-                .get("callId")
-                .and_then(|x| x.as_str())
-                .unwrap_or("")
-                .to_string();
-            let result = v
-                .get("result")
-                .and_then(|x| x.as_str())
-                .unwrap_or("")
-                .to_string();
-            (name, call_id, result)
+            let parsed_name = v.get("name").and_then(|x| x.as_str());
+            let parsed_call_id = v.get("callId").and_then(|x| x.as_str());
+            let parsed_result = v.get("result").and_then(|x| x.as_str());
+            ToolResultRecord {
+                name: parsed_name.unwrap_or("").to_string(),
+                call_id: parsed_call_id.unwrap_or("").to_string(),
+                result: parsed_result.unwrap_or("").to_string(),
+                has_valid_shape: parsed_name.is_some_and(|name| !name.trim().is_empty())
+                    && parsed_call_id.is_some_and(|call_id| !call_id.trim().is_empty())
+                    && parsed_result.is_some(),
+            }
         })
         .collect()
 }
@@ -116,6 +125,7 @@ pub struct ParsedToolResult {
     pub call_id: String,
     pub text: String,
     pub images: Vec<ChatImage>,
+    pub(crate) has_valid_shape: bool,
 }
 
 /// Parse tool_results_json and split `@@image:...@@` tags out of each result
@@ -128,15 +138,22 @@ pub fn parse_tool_results_with_images(
     database_path: &Path,
     skip_image_parsing: bool,
 ) -> Vec<ParsedToolResult> {
-    parse_tool_results_json(raw)
+    parse_tool_result_records(raw)
         .into_iter()
-        .map(|(name, call_id, result)| {
+        .map(|record| {
+            let ToolResultRecord {
+                name,
+                call_id,
+                result,
+                has_valid_shape,
+            } = record;
             if skip_image_parsing || !result.contains("@@image:") {
                 return ParsedToolResult {
                     name,
                     call_id,
                     text: result,
                     images: Vec::new(),
+                    has_valid_shape,
                 };
             }
             match parse_chat_message_content(&result, database_path) {
@@ -145,12 +162,14 @@ pub fn parse_tool_results_with_images(
                     call_id,
                     text: parsed.text,
                     images: parsed.images,
+                    has_valid_shape,
                 },
                 Err(_) => ParsedToolResult {
                     name,
                     call_id,
                     text: result,
                     images: Vec::new(),
+                    has_valid_shape,
                 },
             }
         })
@@ -160,10 +179,12 @@ pub fn parse_tool_results_with_images(
 /// A provider-agnostic representation of a single tool call extracted from
 /// the stored `tool_calls_json`. All conversion functions go through this
 /// intermediate type so they automatically support every provider format.
-struct NormalizedToolCall {
-    id: String,
-    name: String,
-    input: Value,
+pub(crate) struct NormalizedToolCall {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) input: Value,
+    pub(crate) has_valid_name: bool,
+    pub(crate) has_valid_input: bool,
 }
 
 /// Normalize a serialized tool_calls JSON array into [`NormalizedToolCall`]
@@ -172,7 +193,7 @@ struct NormalizedToolCall {
 /// - **OpenAI Responses**: `{"type":"function_call","call_id":"...","name":"...","arguments":"..."}`
 /// - **Anthropic**: `{"type":"tool_use","id":"...","name":"...","input":{...}}`
 /// - **Gemini**: `{"functionCall":{"name":"...","args":{...}}}`
-fn normalize_tool_calls(tool_calls_json: &str) -> Vec<NormalizedToolCall> {
+pub(crate) fn normalize_tool_calls(tool_calls_json: &str) -> Vec<NormalizedToolCall> {
     let Ok(parsed) = serde_json::from_str::<Value>(tool_calls_json) else {
         return Vec::new();
     };
@@ -201,7 +222,7 @@ fn normalize_tool_calls(tool_calls_json: &str) -> Vec<NormalizedToolCall> {
             // OpenAI Chat nests under "function.name"; the other providers
             // use a top-level "name". Gemini nests under
             // "functionCall.name".
-            let name = call
+            let parsed_name = call
                 .get("name")
                 .and_then(Value::as_str)
                 .or_else(|| {
@@ -214,21 +235,25 @@ fn normalize_tool_calls(tool_calls_json: &str) -> Vec<NormalizedToolCall> {
                         .and_then(|f| f.get("name"))
                         .and_then(Value::as_str)
                 })
-                .unwrap_or("unknown_tool")
-                .to_string();
+                .filter(|name| !name.trim().is_empty());
+            let has_valid_name = parsed_name.is_some();
+            let name = parsed_name.unwrap_or("unknown_tool").to_string();
 
             // --- input ---
             // Anthropic stores an object under "input". OpenAI Chat nests a
             // JSON string under "function.arguments"; OpenAI Responses uses a
             // top-level "arguments". Gemini stores an object under
             // "functionCall.args".
-            let input = if let Some(input_val) = call.get("input") {
+            let (input, has_valid_input) = if let Some(input_val) = call.get("input") {
                 if input_val.is_object() {
-                    input_val.clone()
+                    (input_val.clone(), true)
                 } else if let Some(s) = input_val.as_str() {
-                    serde_json::from_str(s).unwrap_or_else(|_| serde_json::json!({}))
+                    match serde_json::from_str::<Value>(s) {
+                        Ok(value) if value.is_object() => (value, true),
+                        _ => (serde_json::json!({}), false),
+                    }
                 } else {
-                    serde_json::json!({})
+                    (serde_json::json!({}), false)
                 }
             } else if let Some(arguments) = call
                 .get("function")
@@ -239,19 +264,32 @@ fn normalize_tool_calls(tool_calls_json: &str) -> Vec<NormalizedToolCall> {
                 // OpenAI Responses uses a top-level "arguments" that is
                 // sometimes a parsed object instead of a string.
                 if arguments.is_object() {
-                    arguments.clone()
+                    (arguments.clone(), true)
                 } else if let Some(s) = arguments.as_str() {
-                    serde_json::from_str(s).unwrap_or_else(|_| serde_json::json!({}))
+                    match serde_json::from_str::<Value>(s) {
+                        Ok(value) if value.is_object() => (value, true),
+                        _ => (serde_json::json!({}), false),
+                    }
                 } else {
-                    serde_json::json!({})
+                    (serde_json::json!({}), false)
                 }
             } else if let Some(args) = call.get("functionCall").and_then(|f| f.get("args")) {
-                args.clone()
+                if args.is_object() {
+                    (args.clone(), true)
+                } else {
+                    (serde_json::json!({}), false)
+                }
             } else {
-                serde_json::json!({})
+                (serde_json::json!({}), false)
             };
 
-            Some(NormalizedToolCall { id, name, input })
+            Some(NormalizedToolCall {
+                id,
+                name,
+                input,
+                has_valid_name,
+                has_valid_input,
+            })
         })
         .collect()
 }

--- a/native/src/api/file_search_agent/mod.rs
+++ b/native/src/api/file_search_agent/mod.rs
@@ -17,7 +17,9 @@ pub(crate) use crate::api::config::{
     get_active_api_request_context, normalize_base_url, resolve_basic_model,
     resolve_sdk_api_base_url,
 };
-pub(crate) use crate::api::gemini::payload::{build_gemini_thinking_config, resolve_gemini_endpoint};
+pub(crate) use crate::api::gemini::payload::{
+    build_gemini_thinking_config, resolve_gemini_endpoint,
+};
 pub(crate) use crate::api::responses::payload::build_responses_reasoning;
 pub(crate) use crate::api::retry::{non_sse_response_error, should_retry, RetryOptions};
 pub(crate) use crate::api::sse::find_sse_separator;
@@ -37,7 +39,9 @@ pub(crate) use crate::storage::services::fs_explorer::{FileSearchLineMatch, File
 
 mod providers;
 
-pub(crate) use providers::{run_anthropic_round, run_chat_round, run_gemini_round, run_responses_round};
+pub(crate) use providers::{
+    run_anthropic_round, run_chat_round, run_gemini_round, run_responses_round,
+};
 
 /// 文件搜索 agent 最多执行的工具调用轮数（模型每次返回工具调用算一轮）。
 const MAX_AGENT_ROUNDS: usize = 10;
@@ -132,7 +136,9 @@ pub async fn run_file_search_agent(
             "content": [{"type": "input_text", "text": user_prompt}],
         })],
         "anthropic" => vec![json!({"role": "user", "content": user_prompt})],
-        "gemini" => vec![json!({"role": "user", "parts": [{"text": user_prompt}]})],
+        "gemini" | "interactions" => {
+            vec![json!({"role": "user", "parts": [{"text": user_prompt}]})]
+        }
         _ => vec![json!({"role": "user", "content": user_prompt})],
     };
 
@@ -153,7 +159,7 @@ pub async fn run_file_search_agent(
                         &messages, &tools, &retry_options, &workspace_root,
                         round, on_progress.as_ref(),
                     ).await,
-                    "gemini" => run_gemini_round(
+                    "gemini" | "interactions" => run_gemini_round(
                         &api_config, &api_key, &custom_headers, &model, &system_prompt,
                         &messages, &tools, &retry_options, &workspace_root,
                         round, on_progress.as_ref(),
@@ -198,7 +204,7 @@ fn push_no_tool_follow_up(messages: &mut Vec<Value>, request_method: &str, text:
             "role": "assistant",
             "content": [{"type": "text", "text": text}],
         }),
-        "gemini" => json!({"role": "model", "parts": [{"text": text}]}),
+        "gemini" | "interactions" => json!({"role": "model", "parts": [{"text": text}]}),
         _ => json!({"role": "assistant", "content": text}),
     };
     let follow_up = match request_method {
@@ -207,7 +213,9 @@ fn push_no_tool_follow_up(messages: &mut Vec<Value>, request_method: &str, text:
             "role": "user",
             "content": [{"type": "input_text", "text": NO_TOOL_FOLLOW_UP_PROMPT}],
         }),
-        "gemini" => json!({"role": "user", "parts": [{"text": NO_TOOL_FOLLOW_UP_PROMPT}]}),
+        "gemini" | "interactions" => {
+            json!({"role": "user", "parts": [{"text": NO_TOOL_FOLLOW_UP_PROMPT}]})
+        }
         _ => json!({"role": "user", "content": NO_TOOL_FOLLOW_UP_PROMPT}),
     };
     messages.push(assistant_message);

--- a/native/src/api/gemini/event.rs
+++ b/native/src/api/gemini/event.rs
@@ -15,6 +15,7 @@ pub(super) fn process_gemini_sse_event_block(
     content_chunks: &mut Vec<String>,
     thinking_chunks: &mut Vec<String>,
     tool_calls: &mut Vec<Value>,
+    signature_parts: &mut Vec<Value>,
     response_id: &mut String,
     response_model: &mut String,
     response_status: &mut String,
@@ -54,6 +55,7 @@ pub(super) fn process_gemini_sse_event_block(
             content_chunks,
             thinking_chunks,
             tool_calls,
+            signature_parts,
             response_id,
             response_model,
             response_status,
@@ -102,6 +104,7 @@ pub(super) fn process_gemini_sse_event_block(
                 content_chunks,
                 thinking_chunks,
                 tool_calls,
+                signature_parts,
                 response_id,
                 response_model,
                 response_status,
@@ -140,6 +143,7 @@ fn process_gemini_event(
     content_chunks: &mut Vec<String>,
     thinking_chunks: &mut Vec<String>,
     tool_calls: &mut Vec<Value>,
+    signature_parts: &mut Vec<Value>,
     response_id: &mut String,
     response_model: &mut String,
     response_status: &mut String,
@@ -161,12 +165,48 @@ fn process_gemini_event(
         *response_model = model;
     }
 
-    if let Some(usage) = event.get("usageMetadata").filter(|value| !value.is_null()) {
-        token_usage.input_tokens = read_first_i64(usage, &[&["promptTokenCount"]]);
-        token_usage.output_tokens =
-            read_first_i64(usage, &[&["candidatesTokenCount"], &["totalTokenCount"]]);
-        token_usage.cache_read_input_tokens =
-            read_first_i64(usage, &[&["cachedContentTokenCount"]]);
+    if let Some(usage) = event
+        .get("usageMetadata")
+        .or_else(|| event.get("usage"))
+        .filter(|value| !value.is_null())
+    {
+        token_usage.input_tokens = read_first_i64(
+            usage,
+            &[
+                &["promptTokenCount"],
+                &["prompt_tokens"],
+                &["input_tokens"],
+                &["total_input_tokens"],
+            ],
+        );
+        let has_cpa_output = usage.get("total_output_tokens").is_some();
+        let mut output_tokens = read_first_i64(
+            usage,
+            &[
+                &["candidatesTokenCount"],
+                &["completion_tokens"],
+                &["output_tokens"],
+                &["total_output_tokens"],
+                &["totalTokenCount"],
+            ],
+        );
+        // CLIProxyAPI reports thinking/tool-use tokens separately. Include
+        // them in Snow's output total when the CPA total is present, matching
+        // the Interactions usage mapping and preventing under-counted runs.
+        if has_cpa_output {
+            output_tokens += read_first_i64(usage, &[&["total_thought_tokens"]]);
+            output_tokens += read_first_i64(usage, &[&["total_tool_use_tokens"]]);
+        }
+        token_usage.output_tokens = output_tokens;
+        token_usage.cache_read_input_tokens = read_first_i64(
+            usage,
+            &[
+                &["cachedContentTokenCount"],
+                &["cache_read_input_tokens"],
+                &["cached_tokens"],
+                &["total_cached_tokens"],
+            ],
+        );
     }
 
     if let Some(prompt_feedback) = event.get("promptFeedback") {
@@ -185,6 +225,17 @@ fn process_gemini_event(
             if let Some(content) = candidate.get("content") {
                 if let Some(parts) = content.get("parts").and_then(Value::as_array) {
                     for part in parts {
+                        // Gemini thoughtSignature is opaque continuation data,
+                        // not displayable thought text. Preserve the complete
+                        // Part so a later functionResponse can continue the
+                        // same reasoning chain without exposing the signature.
+                        if part
+                            .get("thoughtSignature")
+                            .and_then(Value::as_str)
+                            .is_some_and(|signature| !signature.is_empty())
+                        {
+                            signature_parts.push(part.clone());
+                        }
                         let is_thought = part
                             .get("thought")
                             .and_then(Value::as_bool)
@@ -241,10 +292,23 @@ fn process_gemini_event(
 }
 
 /// 将一条 functionCall 合并进工具调用列表，兼容流式 relay 的增量返回：
-/// - 有 name 且已存在同名调用 → 合并 args（增量续传，name 以首个为准）
-/// - 有 name 且无同名调用 → 作为新调用追加
+/// - 有 id 时按 id 合并，保留同名并行调用各自的参数
+/// - 无 id 且有 name 时按名称合并（旧版原生 Gemini 的增量兼容）
+/// - 有 name 且无匹配调用 → 作为新调用追加
 /// - 无 name（纯增量 chunk）→ 合并进最后一个调用
 fn merge_function_call(tool_calls: &mut Vec<Value>, incoming: &Value) {
+    if let Some(id) = incoming.get("id").and_then(Value::as_str) {
+        if let Some(existing) = tool_calls
+            .iter_mut()
+            .rev()
+            .find(|call| call.get("id").and_then(Value::as_str) == Some(id))
+        {
+            merge_function_call_args(existing, incoming);
+            return;
+        }
+        tool_calls.push(incoming.clone());
+        return;
+    }
     let incoming_name = incoming.get("name").and_then(Value::as_str);
     if let Some(name) = incoming_name {
         if let Some(existing) = tool_calls
@@ -268,10 +332,21 @@ fn merge_function_call(tool_calls: &mut Vec<Value>, incoming: &Value) {
 /// 将 incoming 的 args 深合并进 target（后者覆盖前者），并补齐 target
 /// 缺失的其他字段（如 thoughtSignature）。
 fn merge_function_call_args(target: &mut Value, incoming: &Value) {
-    if let Some(incoming_args) = incoming.get("args").filter(|args| args.is_object()) {
+    let incoming_args = incoming
+        .get("args")
+        .or_else(|| incoming.get("arguments"))
+        .filter(|args| args.is_object());
+    if let Some(incoming_args) = incoming_args {
         let incoming_map = incoming_args.as_object().cloned().unwrap_or_default();
         if !incoming_map.is_empty() {
-            match target.get_mut("args") {
+            let target_args_key = if target.get("args").is_some() {
+                "args"
+            } else if target.get("arguments").is_some() {
+                "arguments"
+            } else {
+                "args"
+            };
+            match target.get_mut(target_args_key) {
                 Some(existing) if existing.is_object() => {
                     if let Some(target_map) = existing.as_object_mut() {
                         for (key, value) in incoming_map {
@@ -280,7 +355,7 @@ fn merge_function_call_args(target: &mut Value, incoming: &Value) {
                     }
                 }
                 _ => {
-                    target["args"] = Value::Object(incoming_map);
+                    target[target_args_key] = Value::Object(incoming_map);
                 }
             }
         }
@@ -288,10 +363,159 @@ fn merge_function_call_args(target: &mut Value, incoming: &Value) {
     if let Some(incoming_map) = incoming.as_object() {
         if let Some(target_map) = target.as_object_mut() {
             for (key, value) in incoming_map {
-                if key != "args" && !target_map.contains_key(key) {
+                if key != "args" && key != "arguments" && !target_map.contains_key(key) {
                     target_map.insert(key.clone(), value.clone());
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{merge_function_call, process_gemini_sse_event_block};
+    use crate::storage::services::chat_conversations::ChatTokenUsage;
+    use serde_json::json;
+
+    #[test]
+    fn parses_cli_proxy_usage_aliases_from_gemini_events() {
+        let mut raw_events = Vec::new();
+        let mut content_chunks = Vec::new();
+        let mut thinking_chunks = Vec::new();
+        let mut tool_calls = Vec::new();
+        let mut signature_parts = Vec::new();
+        let mut response_id = String::new();
+        let mut response_model = String::new();
+        let mut response_status = String::new();
+        let mut token_usage = ChatTokenUsage::default();
+        let mut tool_args_delta = String::new();
+        let mut stream_finished = false;
+
+        process_gemini_sse_event_block(
+            r#"data: {"usage":{"total_input_tokens":6,"total_output_tokens":1,"total_thought_tokens":95,"total_tool_use_tokens":2,"total_cached_tokens":2}}"#,
+            &mut raw_events,
+            &mut content_chunks,
+            &mut thinking_chunks,
+            &mut tool_calls,
+            &mut signature_parts,
+            &mut response_id,
+            &mut response_model,
+            &mut response_status,
+            &mut token_usage,
+            &mut tool_args_delta,
+            &mut stream_finished,
+        );
+
+        assert_eq!(token_usage.input_tokens, 6);
+        assert_eq!(token_usage.output_tokens, 98);
+        assert_eq!(token_usage.cache_read_input_tokens, 2);
+    }
+
+    #[test]
+    fn preserves_function_call_and_signature_as_opaque_part() {
+        let mut raw_events = Vec::new();
+        let mut content_chunks = Vec::new();
+        let mut thinking_chunks = Vec::new();
+        let mut tool_calls = Vec::new();
+        let mut signature_parts = Vec::new();
+        let mut response_id = String::new();
+        let mut response_model = String::new();
+        let mut response_status = String::new();
+        let mut token_usage = ChatTokenUsage::default();
+        let mut tool_args_delta = String::new();
+        let mut stream_finished = false;
+
+        process_gemini_sse_event_block(
+            r#"data: {"candidates":[{"content":{"parts":[{"functionCall":{"id":"call-1","name":"filesystem-read","args":{"filePath":"README.md"}},"thoughtSignature":"opaque-signature"}]}}]}"#,
+            &mut raw_events,
+            &mut content_chunks,
+            &mut thinking_chunks,
+            &mut tool_calls,
+            &mut signature_parts,
+            &mut response_id,
+            &mut response_model,
+            &mut response_status,
+            &mut token_usage,
+            &mut tool_args_delta,
+            &mut stream_finished,
+        );
+
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(
+            signature_parts,
+            vec![json!({
+                "functionCall": { "id": "call-1", "name": "filesystem-read", "args": { "filePath": "README.md" } },
+                "thoughtSignature": "opaque-signature",
+            })]
+        );
+        assert!(thinking_chunks.is_empty());
+    }
+
+    #[test]
+    fn ignores_empty_or_malformed_signatures() {
+        let mut raw_events = Vec::new();
+        let mut content_chunks = Vec::new();
+        let mut thinking_chunks = Vec::new();
+        let mut tool_calls = Vec::new();
+        let mut signature_parts = Vec::new();
+        let mut response_id = String::new();
+        let mut response_model = String::new();
+        let mut response_status = String::new();
+        let mut token_usage = ChatTokenUsage::default();
+        let mut tool_args_delta = String::new();
+        let mut stream_finished = false;
+
+        process_gemini_sse_event_block(
+            r#"data: {"candidates":[{"content":{"parts":[{"thoughtSignature":""},{"thoughtSignature":42}]}}]}"#,
+            &mut raw_events,
+            &mut content_chunks,
+            &mut thinking_chunks,
+            &mut tool_calls,
+            &mut signature_parts,
+            &mut response_id,
+            &mut response_model,
+            &mut response_status,
+            &mut token_usage,
+            &mut tool_args_delta,
+            &mut stream_finished,
+        );
+        assert!(signature_parts.is_empty());
+    }
+
+    #[test]
+    fn keeps_same_name_parallel_function_calls_separate_by_id() {
+        let mut tool_calls = Vec::new();
+        merge_function_call(
+            &mut tool_calls,
+            &json!({
+                "id": "call-package",
+                "name": "filesystem-read",
+                "args": { "filePath": "package.json" },
+            }),
+        );
+        merge_function_call(
+            &mut tool_calls,
+            &json!({
+                "id": "call-readme",
+                "name": "filesystem-read",
+                "args": { "filePath": "README.md" },
+            }),
+        );
+
+        assert_eq!(
+            tool_calls,
+            vec![
+                json!({
+                    "id": "call-package",
+                    "name": "filesystem-read",
+                    "args": { "filePath": "package.json" },
+                }),
+                json!({
+                    "id": "call-readme",
+                    "name": "filesystem-read",
+                    "args": { "filePath": "README.md" },
+                }),
+            ]
+        );
     }
 }

--- a/native/src/api/gemini/mod.rs
+++ b/native/src/api/gemini/mod.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use napi::bindgen_prelude::*;
+use serde_json::{json, Value};
 use tokio_util::sync::CancellationToken;
 
 use crate::api::config::resolve_advanced_model;
@@ -31,6 +32,77 @@ use crate::storage::services::chat_conversations::{
     store_chat_exchange, ChatContextMessage, StoreChatExchangeInput,
 };
 use crate::storage::ApiConfigRecord;
+
+/// Produce a recovery-only protocol audit without persisting prompts, tool
+/// arguments/results, credentials, or opaque Gemini thought signatures.
+fn gemini_recovery_outbound_audit(payload: &Value) -> String {
+    let contents = payload
+        .get("contents")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let (function_calls, function_responses) = contents
+        .iter()
+        .flat_map(|content| {
+            content
+                .get("parts")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+        })
+        .fold((0usize, 0usize), |(calls, responses), part| {
+            (
+                calls + usize::from(part.get("functionCall").is_some()),
+                responses + usize::from(part.get("functionResponse").is_some()),
+            )
+        });
+    let tool_entries = payload.get("tools").and_then(Value::as_array);
+    let function_declarations = tool_entries
+        .into_iter()
+        .flatten()
+        .map(|tool| {
+            tool.get("functionDeclarations")
+                .and_then(Value::as_array)
+                .map_or(0, Vec::len)
+        })
+        .sum::<usize>();
+    let google_search_entries = tool_entries
+        .into_iter()
+        .flatten()
+        .filter(|tool| tool.get("googleSearch").is_some())
+        .count();
+    json!({
+        "contents": contents.len(),
+        "functionCallParts": function_calls,
+        "functionResponseParts": function_responses,
+        "toolsField": if tool_entries.is_some() { "present" } else { "absent" },
+        "functionDeclarations": function_declarations,
+        "googleSearchEntries": google_search_entries,
+        "systemInstructionParts": payload
+            .pointer("/systemInstruction/parts")
+            .and_then(Value::as_array)
+            .map_or(0, Vec::len),
+    })
+    .to_string()
+}
+
+fn gemini_recovery_inbound_audit(streamed_response: &stream::GeminiStreamResult) -> String {
+    let tool_calls =
+        serde_json::from_str::<Vec<Value>>(&streamed_response.tool_calls_json).unwrap_or_default();
+    let tool_names = tool_calls
+        .iter()
+        .filter_map(|tool| tool.get("name").and_then(Value::as_str))
+        .collect::<Vec<_>>();
+    json!({
+        "status": streamed_response.status,
+        "contentChars": streamed_response.content.chars().count(),
+        "thinkingChars": streamed_response.thinking.chars().count(),
+        "toolCallCount": tool_calls.len(),
+        "toolNames": tool_names,
+        "durationMs": streamed_response.total_duration_ms,
+    })
+    .to_string()
+}
 
 /// Public entry point — create a Gemini streaming response.
 pub async fn create_gemini_response_stream(
@@ -129,7 +201,10 @@ async fn create_gemini_response_async(
     )
     .await?;
 
-    let tools = if request.context_compaction.unwrap_or(false) || skip_context {
+    let tools = if request.context_compaction.unwrap_or(false)
+        || skip_context
+        || request.disable_tools.unwrap_or(false)
+    {
         None
     } else {
         match resolve_sub_agent_tools(&request).await {
@@ -148,6 +223,15 @@ async fn create_gemini_response_async(
         tools,
         &prepared_request.user_system_prompts,
     )?;
+    let is_duplicate_recovery = request.disable_tools.unwrap_or(false);
+    if is_duplicate_recovery {
+        log_api_warning(
+            &database_path,
+            "gemini_duplicate_recovery_outbound",
+            "Gemini duplicate recovery protocol audit",
+            &gemini_recovery_outbound_audit(&payload),
+        );
+    }
     let retry_options = RetryOptions::from_config(
         api_config.max_retries,
         api_config.retry_base_delay_ms,
@@ -187,6 +271,14 @@ async fn create_gemini_response_async(
             return Err(error);
         }
     };
+    if is_duplicate_recovery {
+        log_api_warning(
+            &database_path,
+            "gemini_duplicate_recovery_inbound",
+            "Gemini duplicate recovery protocol audit",
+            &gemini_recovery_inbound_audit(&streamed_response),
+        );
+    }
     // See chat/mod.rs: assistant raw_events are not needed for replay, so we
     // skip serializing the full SSE chunk array to avoid DB bloat.
     let raw_response_json = "{}";
@@ -261,7 +353,7 @@ async fn create_gemini_response_async(
                 raw_response_json: &raw_response_json,
                 token_usage: streamed_response.token_usage,
                 response_thinking: &streamed_response.thinking,
-                response_thinking_blocks_json: "[]",
+                response_thinking_blocks_json: &streamed_response.thinking_blocks_json,
                 tool_calls_json: &streamed_response.tool_calls_json,
                 directory_id: request.directory_id.as_deref().unwrap_or(""),
                 context_compaction: request.context_compaction.unwrap_or(false),

--- a/native/src/api/gemini/payload.rs
+++ b/native/src/api/gemini/payload.rs
@@ -106,8 +106,11 @@ pub(super) fn build_gemini_payload(
                 } else {
                     serde_json::json!({"result": text})
                 };
-                let tool_name =
-                    resolve_function_response_name(tool_result, &mut call_id_to_name, &mut pending_call_names);
+                let tool_name = resolve_function_response_name(
+                    tool_result,
+                    &mut call_id_to_name,
+                    &mut pending_call_names,
+                );
                 contents.push(json!({
                     "role": "function",
                     "parts": [{
@@ -288,20 +291,24 @@ pub(super) fn build_gemini_payload(
     }
 
     // Google Search grounding（Gemini 原生联网搜索）：
-    // 配置 snowcfg.googleSearch 开启时，向 tools 数组注入 google_search 工具。
-    // 与 MCP function tools 可共存，Gemini 允许 tools 中混合声明与内置工具。
+    // 配置 snowcfg.googleSearch 开启时，合并注入 google_search。
+    // 与 MCP function tools 共存时，放入同一个 Tool 对象并配置 tool_config.include_server_side_tool_invocations。
     if build_gemini_google_search_enabled(&api_config.config_json) {
-        let has_tools = payload
-            .get("tools")
-            .and_then(Value::as_array)
-            .is_some_and(|items| !items.is_empty());
-        if !has_tools {
-            payload["tools"] = json!([]);
+        if let Some(tools_arr) = payload.get_mut("tools").and_then(Value::as_array_mut) {
+            if let Some(first_tool) = tools_arr.first_mut().and_then(Value::as_object_mut) {
+                first_tool.insert("google_search".to_string(), json!({}));
+                payload["tool_config"] = json!({
+                    "include_server_side_tool_invocations": true
+                });
+                payload["toolConfig"] = json!({
+                    "includeServerSideToolInvocations": true
+                });
+            } else {
+                tools_arr.push(json!({ "google_search": {} }));
+            }
+        } else {
+            payload["tools"] = json!([{ "google_search": {} }]);
         }
-        payload["tools"]
-            .as_array_mut()
-            .expect("tools is an array")
-            .push(json!({ "google_search": {} }));
     }
 
     Ok(payload)

--- a/native/src/api/gemini/payload.rs
+++ b/native/src/api/gemini/payload.rs
@@ -11,7 +11,8 @@ use crate::api::config::{
 };
 use crate::api::conversation::parse_chat_message_content;
 use crate::api::conversation::tool_messages::{
-    extract_tool_call_entries, parse_tool_results_with_images, ParsedToolResult,
+    extract_tool_call_entries, parse_tool_results_with_images, remove_invalid_snow_tool_calls,
+    ParsedToolResult,
 };
 use crate::api::responses::ResponsesApiRequest;
 use crate::storage::services::chat_conversations::ChatContextMessage;
@@ -53,6 +54,29 @@ pub(crate) fn resolve_gemini_endpoint(
     url
 }
 
+fn build_gemini_system_instruction(
+    user_system_prompts: &[String],
+    builtin_system_parts: Vec<String>,
+    internal_recovery_prompt: Option<&str>,
+) -> Option<Value> {
+    let mut system_parts = if user_system_prompts.is_empty() {
+        builtin_system_parts
+    } else {
+        user_system_prompts.to_vec()
+    };
+    if let Some(prompt) = internal_recovery_prompt
+        .map(str::trim)
+        .filter(|prompt| !prompt.is_empty())
+    {
+        system_parts.push(prompt.to_string());
+    }
+    (!system_parts.is_empty()).then(|| {
+        json!({
+            "parts": system_parts.into_iter().map(|text| json!({ "text": text })).collect::<Vec<_>>()
+        })
+    })
+}
+
 pub(super) fn build_gemini_payload(
     messages: &[ChatContextMessage],
     database_path: &Path,
@@ -61,6 +85,11 @@ pub(super) fn build_gemini_payload(
     tools: Option<Value>,
     user_system_prompts: &[String],
 ) -> Result<Value> {
+    // Never mutate database-backed history. Gemini requests receive a filtered
+    // copy so an upstream empty built-in call and its error result cannot seed
+    // a self-reinforcing function-call retry loop.
+    let mut messages = messages.to_vec();
+    remove_invalid_snow_tool_calls(&mut messages);
     let skip_image_parsing = request.skip_context.unwrap_or(false);
     let has_user_system_prompts = !user_system_prompts.is_empty();
     let mut builtin_system_parts = Vec::new();
@@ -79,13 +108,13 @@ pub(super) fn build_gemini_payload(
     let mut call_id_to_name: HashMap<String, String> = HashMap::new();
     let mut pending_call_names: VecDeque<String> = VecDeque::new();
 
-    for message in messages {
+    for message in &messages {
         let content = message.content.trim();
         let role = message.role.trim();
 
-        // --- Tool result messages: emit as function role with functionResponse parts ---
+        // --- Tool result messages: emit as user content with functionResponse parts ---
         if role == "tool" {
-            if content.is_empty() {
+            if content.is_empty() && message.tool_results_json.is_none() {
                 continue;
             }
             let results = match message.tool_results_json {
@@ -94,31 +123,40 @@ pub(super) fn build_gemini_payload(
                 }
                 None => Vec::new(),
             };
+            // Gemini requires tool results as user Content with ordered
+            // functionResponse parts. Keep image-bearing responses separate:
+            // their inlineData must remain a following user content block.
+            if results
+                .iter()
+                .all(|tool_result| tool_result.images.is_empty())
+            {
+                let parts: Vec<Value> = results
+                    .iter()
+                    .map(|tool_result| {
+                        build_function_response_part(
+                            tool_result,
+                            &call_id_to_name,
+                            &mut pending_call_names,
+                        )
+                    })
+                    .collect();
+                if !parts.is_empty() {
+                    contents.push(json!({
+                        "role": "user",
+                        "parts": parts,
+                    }));
+                }
+                continue;
+            }
+
             for tool_result in &results {
-                let has_images = !tool_result.images.is_empty();
-                let text = tool_result.text.clone();
-                let response_content = if text.is_empty() {
-                    if has_images {
-                        serde_json::json!({"result": "[image attached]"})
-                    } else {
-                        serde_json::json!({"result": "ok"})
-                    }
-                } else {
-                    serde_json::json!({"result": text})
-                };
-                let tool_name = resolve_function_response_name(
-                    tool_result,
-                    &mut call_id_to_name,
-                    &mut pending_call_names,
-                );
                 contents.push(json!({
-                    "role": "function",
-                    "parts": [{
-                        "functionResponse": {
-                            "name": tool_name,
-                            "response": response_content,
-                        }
-                    }],
+                    "role": "user",
+                    "parts": [build_function_response_part(
+                        tool_result,
+                        &call_id_to_name,
+                        &mut pending_call_names,
+                    )],
                 }));
                 // functionResponse only accepts plain JSON, so the screenshot
                 // base64 must travel in a following user message as inlineData
@@ -145,7 +183,9 @@ pub(super) fn build_gemini_payload(
             continue;
         }
 
-        if content.is_empty() && message.tool_calls_json.is_none() {
+        let has_replayable_signatures =
+            has_replayable_gemini_signatures(message.thinking_blocks_json.as_deref());
+        if content.is_empty() && message.tool_calls_json.is_none() && !has_replayable_signatures {
             continue;
         }
 
@@ -167,23 +207,51 @@ pub(super) fn build_gemini_payload(
                 }
                 if !function_call_parts.is_empty() {
                     let mut parts = Vec::new();
-                    // Round-trip thinking as a thought text part so Gemini
-                    // retains its prior reasoning across turns.
-                    if let Some(ref thinking) = message.thinking {
-                        if !thinking.is_empty() {
-                            parts.push(json!({ "text": thinking, "thought": true }));
+                    // Signed Parts carry their own thought text when present.
+                    // Replaying the display-oriented thinking mirror beside
+                    // them would duplicate model reasoning in the next turn.
+                    if !has_replayable_signatures {
+                        if let Some(ref thinking) = message.thinking {
+                            if !thinking.is_empty() {
+                                parts.push(json!({ "text": thinking, "thought": true }));
+                            }
                         }
                     }
                     if !content.is_empty() {
                         parts.push(json!({ "text": content }));
                     }
-                    parts.extend(function_call_parts);
+                    parts.extend(replay_signed_function_call_parts(
+                        function_call_parts,
+                        message.thinking_blocks_json.as_deref(),
+                    ));
                     contents.push(json!({
                         "role": "model",
                         "parts": parts,
                     }));
                     continue;
                 }
+            }
+
+            // Gemini may emit a thoughtSignature on a normal model Part
+            // without a functionCall. It is still required continuation data
+            // and must be replayed as a model Part, even though there is no
+            // tool result in the following turn.
+            if has_replayable_signatures {
+                let mut parts = Vec::new();
+                if !content.is_empty() {
+                    parts.push(json!({ "text": content }));
+                }
+                parts.extend(replay_signed_function_call_parts(
+                    Vec::new(),
+                    message.thinking_blocks_json.as_deref(),
+                ));
+                if !parts.is_empty() {
+                    contents.push(json!({
+                        "role": "model",
+                        "parts": parts,
+                    }));
+                }
+                continue;
             }
         }
 
@@ -250,18 +318,12 @@ pub(super) fn build_gemini_payload(
     // Build `systemInstruction`. When user system prompts are present they
     // occupy the field exclusively (each prompt as an independent part).
     // Otherwise the built-in system prompt parts are used.
-    let system_parts: Vec<&String> = if has_user_system_prompts {
-        user_system_prompts.iter().collect()
-    } else {
-        builtin_system_parts.iter().collect()
-    };
-
-    if !system_parts.is_empty() {
-        let parts: Vec<Value> = system_parts
-            .iter()
-            .map(|text| json!({ "text": text }))
-            .collect();
-        payload["systemInstruction"] = json!({ "parts": parts });
+    if let Some(system_instruction) = build_gemini_system_instruction(
+        user_system_prompts,
+        builtin_system_parts,
+        request.internal_recovery_prompt.as_deref(),
+    ) {
+        payload["systemInstruction"] = system_instruction;
     }
 
     let mut generation_config = json!({});
@@ -293,25 +355,135 @@ pub(super) fn build_gemini_payload(
     // Google Search grounding（Gemini 原生联网搜索）：
     // 配置 snowcfg.googleSearch 开启时，合并注入 google_search。
     // 与 MCP function tools 共存时，放入同一个 Tool 对象并配置 tool_config.include_server_side_tool_invocations。
-    if build_gemini_google_search_enabled(&api_config.config_json) {
+    // A duplicate-read recovery deliberately has no provider tools at all.
+    // Google Search is a provider tool too, even though it is configured
+    // independently from MCP function declarations.
+    let google_search_enabled = should_include_gemini_google_search(
+        &api_config.config_json,
+        request.disable_tools.unwrap_or(false),
+    );
+    let is_cli_proxy_api = api_config
+        .base_url
+        .to_ascii_lowercase()
+        .contains("cliproxyapi");
+    let has_function_tools = payload
+        .get("tools")
+        .and_then(Value::as_array)
+        .is_some_and(|items| !items.is_empty());
+    // The current CPA/Antigravity route rejects built-in tools mixed with
+    // function declarations. MCP tools remain usable, so omit only the
+    // built-in search tool for that route when both are configured.
+    let include_google_search = google_search_enabled && !(is_cli_proxy_api && has_function_tools);
+    if include_google_search {
         if let Some(tools_arr) = payload.get_mut("tools").and_then(Value::as_array_mut) {
-            if let Some(first_tool) = tools_arr.first_mut().and_then(Value::as_object_mut) {
-                first_tool.insert("google_search".to_string(), json!({}));
-                payload["tool_config"] = json!({
-                    "include_server_side_tool_invocations": true
-                });
-                payload["toolConfig"] = json!({
-                    "includeServerSideToolInvocations": true
-                });
-            } else {
-                tools_arr.push(json!({ "google_search": {} }));
-            }
+            // Keep server-side and function tools as separate Tool objects.
+            // CPA rejects a single object that mixes google_search with
+            // functionDeclarations even when tool_config is present.
+            tools_arr.push(json!({ "google_search": {} }));
         } else {
             payload["tools"] = json!([{ "google_search": {} }]);
         }
+        // CPA requires this flag whenever a built-in tool is combined with
+        // function calling, including the Google-Search-only case where the
+        // tools array did not exist before the branch above.
+        payload["tool_config"] = json!({
+            "include_server_side_tool_invocations": true
+        });
+        payload["toolConfig"] = json!({
+            "includeServerSideToolInvocations": true
+        });
+    } else if is_cli_proxy_api && has_function_tools {
+        // CPA can inject/enable built-in tools while Snow only sees the MCP
+        // function declarations. Send the compatibility flag for any
+        // function-tool request as well, otherwise CPA rejects the request
+        // before streaming starts.
+        payload["tool_config"] = json!({
+            "include_server_side_tool_invocations": true,
+            "function_calling_config": { "mode": "AUTO" }
+        });
+        payload["toolConfig"] = json!({
+            "includeServerSideToolInvocations": true,
+            "functionCallingConfig": { "mode": "AUTO" }
+        });
     }
 
     Ok(payload)
+}
+
+/// Rehydrate Gemini's opaque thoughtSignature Parts for tool continuation.
+/// Old rows and signatures from other providers are ignored, leaving the
+/// normal normalized functionCall representation untouched.
+fn replay_signed_function_call_parts(
+    function_call_parts: Vec<Value>,
+    thinking_blocks_json: Option<&str>,
+) -> Vec<Value> {
+    let Some(signature_parts) = thinking_blocks_json
+        .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
+        .and_then(|value| value.as_array().cloned())
+    else {
+        return function_call_parts;
+    };
+
+    let remaining = signature_parts
+        .into_iter()
+        .filter(|part| {
+            part.get("thoughtSignature")
+                .and_then(Value::as_str)
+                .is_some_and(|signature| !signature.is_empty())
+        })
+        .collect::<Vec<_>>();
+    let mut remaining_calls = function_call_parts;
+    let mut replayed = Vec::new();
+
+    // Preserve the provider's Part order. A thoughtSignature can occur on a
+    // function-call Part or on a signature-only thought Part; both must remain
+    // before the matching user functionResponse in the next request.
+    for signed_part in remaining {
+        let Some(signed_call) = signed_part.get("functionCall") else {
+            replayed.push(signed_part);
+            continue;
+        };
+        let signed_id = signed_call.get("id").and_then(Value::as_str);
+        let signed_name = signed_call.get("name").and_then(Value::as_str);
+        let match_index = remaining_calls.iter().position(|function_call_part| {
+            let function_call = function_call_part.get("functionCall");
+            let call_id = function_call
+                .and_then(|call| call.get("id"))
+                .and_then(Value::as_str);
+            let call_name = function_call
+                .and_then(|call| call.get("name"))
+                .and_then(Value::as_str);
+            match (call_id, signed_id) {
+                (Some(call_id), Some(signed_id)) => call_id == signed_id,
+                (None, None) => call_name == signed_name,
+                _ => false,
+            }
+        });
+        if let Some(index) = match_index {
+            let function_call_part = remaining_calls.remove(index);
+            let mut replay_part = signed_part;
+            replay_part["functionCall"] = function_call_part["functionCall"].clone();
+            replayed.push(replay_part);
+        }
+    }
+
+    // Legacy rows may not have a signature for every stored call. Keep those
+    // calls in their normalized form rather than deleting usable history.
+    replayed.extend(remaining_calls);
+    replayed
+}
+
+fn has_replayable_gemini_signatures(thinking_blocks_json: Option<&str>) -> bool {
+    thinking_blocks_json
+        .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
+        .and_then(|value| value.as_array().cloned())
+        .is_some_and(|parts| {
+            parts.iter().any(|part| {
+                part.get("thoughtSignature")
+                    .and_then(Value::as_str)
+                    .is_some_and(|signature| !signature.is_empty())
+            })
+        })
 }
 
 fn normalize_gemini_role(role: &str) -> &str {
@@ -349,6 +521,36 @@ fn resolve_function_response_name(
     }
 }
 
+fn build_function_response_part(
+    tool_result: &ParsedToolResult,
+    call_id_to_name: &HashMap<String, String>,
+    pending_call_names: &mut VecDeque<String>,
+) -> Value {
+    let response_content = if tool_result.text.is_empty() {
+        if tool_result.images.is_empty() {
+            json!({"result": "ok"})
+        } else {
+            json!({"result": "[image attached]"})
+        }
+    } else {
+        json!({"result": tool_result.text})
+    };
+    let mut function_response = serde_json::Map::new();
+    if !tool_result.call_id.is_empty() {
+        function_response.insert("id".to_string(), Value::String(tool_result.call_id.clone()));
+    }
+    function_response.insert(
+        "name".to_string(),
+        Value::String(resolve_function_response_name(
+            tool_result,
+            call_id_to_name,
+            pending_call_names,
+        )),
+    );
+    function_response.insert("response".to_string(), response_content);
+    json!({ "functionResponse": function_response })
+}
+
 pub(crate) fn build_gemini_thinking_config(config_json: &str) -> Option<Value> {
     let parsed = serde_json::from_str::<Value>(config_json).ok()?;
     let gemini_thinking = parsed.get("snowcfg")?.get("geminiThinking")?.as_object()?;
@@ -366,7 +568,10 @@ pub(crate) fn build_gemini_thinking_config(config_json: &str) -> Option<Value> {
         .map(str::trim)
         .filter(|value| !value.is_empty() && *value != "none")?;
 
-    Some(json!({ "thinkingLevel": thinking_level }))
+    Some(json!({
+        "thinkingLevel": thinking_level,
+        "includeThoughts": true,
+    }))
 }
 
 /// 读取配置中的谷歌搜索联网开关（snowcfg.googleSearch）。
@@ -376,4 +581,217 @@ pub(crate) fn build_gemini_google_search_enabled(config_json: &str) -> bool {
         .ok()
         .and_then(|parsed| parsed.get("snowcfg")?.get("googleSearch")?.as_bool())
         .unwrap_or(false)
+}
+
+pub(crate) fn should_include_gemini_google_search(config_json: &str, disable_tools: bool) -> bool {
+    !disable_tools && build_gemini_google_search_enabled(config_json)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, VecDeque};
+
+    use super::{
+        build_function_response_part, build_gemini_system_instruction,
+        build_gemini_thinking_config, has_replayable_gemini_signatures,
+        replay_signed_function_call_parts, should_include_gemini_google_search,
+    };
+    use crate::api::conversation::images::ChatImage;
+    use crate::api::conversation::tool_messages::ParsedToolResult;
+    use serde_json::{json, Value};
+
+    fn parsed_tool_result(name: &str, call_id: &str, text: &str) -> ParsedToolResult {
+        ParsedToolResult {
+            name: name.to_string(),
+            call_id: call_id.to_string(),
+            text: text.to_string(),
+            images: Vec::<ChatImage>::new(),
+            has_valid_shape: true,
+        }
+    }
+
+    #[test]
+    fn requests_thought_summaries_when_gemini_thinking_is_enabled() {
+        let config = json!({
+            "snowcfg": {
+                "geminiThinking": {
+                    "enabled": true,
+                    "thinkingLevel": "high"
+                }
+            }
+        })
+        .to_string();
+
+        assert_eq!(
+            build_gemini_thinking_config(&config),
+            Some(json!({
+                "thinkingLevel": "high",
+                "includeThoughts": true,
+            }))
+        );
+    }
+
+    #[test]
+    fn internal_recovery_prompt_is_a_gemini_system_instruction() {
+        let payload = build_gemini_system_instruction(
+            &["configured system rule".to_string()],
+            vec!["built-in protocol".to_string()],
+            Some("Use completed results and answer without tools."),
+        )
+        .expect("system instruction");
+
+        assert_eq!(
+            payload,
+            json!({"parts": [
+                {"text": "configured system rule"},
+                {"text": "Use completed results and answer without tools."}
+            ]})
+        );
+        assert!(!payload.to_string().contains("built-in protocol"));
+    }
+
+    #[test]
+    fn disabled_tools_also_disable_configured_gemini_google_search() {
+        let config = json!({ "snowcfg": { "googleSearch": true } }).to_string();
+
+        assert!(should_include_gemini_google_search(&config, false));
+        assert!(!should_include_gemini_google_search(&config, true));
+    }
+
+    #[test]
+    fn omits_thinking_config_when_gemini_thinking_is_explicitly_disabled() {
+        let config = json!({
+            "snowcfg": {
+                "geminiThinking": {
+                    "enabled": false,
+                    "thinkingLevel": "high"
+                }
+            }
+        })
+        .to_string();
+
+        assert_eq!(build_gemini_thinking_config(&config), None);
+    }
+
+    #[test]
+    fn omits_thinking_config_when_thinking_level_is_none() {
+        let config = json!({
+            "snowcfg": {
+                "geminiThinking": {
+                    "enabled": true,
+                    "thinkingLevel": "none"
+                }
+            }
+        })
+        .to_string();
+
+        assert_eq!(build_gemini_thinking_config(&config), None);
+    }
+
+    #[test]
+    fn omits_thinking_config_for_invalid_configuration() {
+        assert_eq!(build_gemini_thinking_config("not json"), None);
+    }
+
+    #[test]
+    fn parallel_gemini_tool_responses_keep_the_matching_call_ids_and_order() {
+        let call_id_to_name = HashMap::from([
+            ("call-read".to_string(), "filesystem-read".to_string()),
+            ("call-list".to_string(), "filesystem-read".to_string()),
+        ]);
+        let mut pending_call_names = VecDeque::new();
+        let first = parsed_tool_result("wrong-name", "call-read", "package content");
+        let second = parsed_tool_result("wrong-name", "call-list", "directory content");
+
+        let parts = vec![
+            build_function_response_part(&first, &call_id_to_name, &mut pending_call_names),
+            build_function_response_part(&second, &call_id_to_name, &mut pending_call_names),
+        ];
+
+        assert_eq!(
+            json!({ "role": "user", "parts": parts }),
+            json!({
+                "role": "user",
+                "parts": [
+                    { "functionResponse": {
+                        "id": "call-read",
+                        "name": "filesystem-read",
+                        "response": { "result": "package content" },
+                    }},
+                    { "functionResponse": {
+                        "id": "call-list",
+                        "name": "filesystem-read",
+                        "response": { "result": "directory content" },
+                    }},
+                ],
+            })
+        );
+        // The call map is read-only while results are matched, so parallel
+        // responses cannot consume or overwrite each other's identifiers.
+        assert_eq!(call_id_to_name.len(), 2);
+    }
+
+    #[test]
+    fn replays_parallel_signed_function_calls_by_id() {
+        let calls = vec![
+            json!({ "functionCall": { "id": "readme", "name": "filesystem-read", "args": { "filePath": "README.md" } } }),
+            json!({ "functionCall": { "id": "package", "name": "filesystem-read", "args": { "filePath": "package.json" } } }),
+        ];
+        let signatures = json!([
+            { "functionCall": { "id": "package", "name": "filesystem-read", "args": {} }, "thoughtSignature": "sig-package" },
+            { "functionCall": { "id": "readme", "name": "filesystem-read", "args": {} }, "thoughtSignature": "sig-readme" },
+        ]).to_string();
+
+        assert_eq!(
+            replay_signed_function_call_parts(calls, Some(&signatures)),
+            vec![
+                json!({ "functionCall": { "id": "package", "name": "filesystem-read", "args": { "filePath": "package.json" } }, "thoughtSignature": "sig-package" }),
+                json!({ "functionCall": { "id": "readme", "name": "filesystem-read", "args": { "filePath": "README.md" } }, "thoughtSignature": "sig-readme" }),
+            ],
+        );
+    }
+
+    #[test]
+    fn replays_signature_only_parts_and_keeps_legacy_calls() {
+        let calls = vec![
+            json!({ "functionCall": { "id": "call-1", "name": "filesystem-read", "args": {} } }),
+        ];
+        let signatures = json!([
+            { "thoughtSignature": "continuation-only" },
+            { "functionCall": { "id": "different", "name": "filesystem-read", "args": {} }, "thoughtSignature": "unmatched" },
+            { "thoughtSignature": "" },
+        ]).to_string();
+        assert_eq!(
+            replay_signed_function_call_parts(calls.clone(), Some(&signatures)),
+            vec![
+                json!({ "thoughtSignature": "continuation-only" }),
+                calls[0].clone(),
+            ],
+        );
+        assert_eq!(
+            replay_signed_function_call_parts(calls.clone(), None),
+            calls
+        );
+        assert_eq!(
+            replay_signed_function_call_parts(calls.clone(), Some("not json")),
+            calls
+        );
+    }
+
+    #[test]
+    fn preserves_signature_only_model_parts_without_tool_calls() {
+        let signatures = json!([
+            { "text": "private reasoning", "thought": true, "thoughtSignature": "opaque" },
+            { "thoughtSignature": "continuation-only" },
+        ])
+        .to_string();
+
+        assert_eq!(
+            replay_signed_function_call_parts(Vec::new(), Some(&signatures)),
+            serde_json::from_str::<Vec<Value>>(&signatures).unwrap(),
+        );
+        assert!(has_replayable_gemini_signatures(Some(&signatures)));
+        assert!(!has_replayable_gemini_signatures(Some("not json")));
+        assert!(!has_replayable_gemini_signatures(Some("[]")));
+    }
 }

--- a/native/src/api/gemini/stream.rs
+++ b/native/src/api/gemini/stream.rs
@@ -29,6 +29,7 @@ pub(super) struct GeminiStreamResult {
     pub id: String,
     pub content: String,
     pub thinking: String,
+    pub thinking_blocks_json: String,
     pub model: String,
     pub status: String,
     pub interruption_reason: Option<StreamInterruptionReason>,
@@ -61,6 +62,7 @@ pub(super) async fn collect_gemini_stream(
                 id: String::new(),
                 content: String::new(),
                 thinking: String::new(),
+                thinking_blocks_json: "[]".to_string(),
                 model: String::new(),
                 status: String::from("cancelled"),
                 interruption_reason: None,
@@ -77,6 +79,7 @@ pub(super) async fn collect_gemini_stream(
                     id: String::new(),
                     content: String::new(),
                     thinking: String::new(),
+                    thinking_blocks_json: "[]".to_string(),
                     model: String::new(),
                     status: String::from("cancelled"),
                     interruption_reason: None,
@@ -100,6 +103,7 @@ pub(super) async fn collect_gemini_stream(
                         id: String::new(),
                         content: String::new(),
                         thinking: String::new(),
+                        thinking_blocks_json: "[]".to_string(),
                         model: String::new(),
                         status: String::from("cancelled"),
                         interruption_reason: None,
@@ -197,6 +201,7 @@ pub(super) async fn collect_gemini_stream(
         let mut content_chunks = Vec::new();
         let mut thinking_chunks = Vec::new();
         let mut tool_calls = Vec::new();
+        let mut signature_parts = Vec::new();
         let mut response_id = String::new();
         let mut response_model = String::new();
         let mut response_status = String::from("completed");
@@ -219,6 +224,7 @@ pub(super) async fn collect_gemini_stream(
                     &mut content_chunks,
                     &mut thinking_chunks,
                     &mut tool_calls,
+                    &mut signature_parts,
                     &mut response_id,
                     &mut response_model,
                     &mut response_status,
@@ -286,6 +292,7 @@ pub(super) async fn collect_gemini_stream(
         if response_status == "cancelled" || cancel_token.is_cancelled() {
             response_status = String::from("cancelled");
             tool_calls.clear();
+            signature_parts.clear();
             interruption_reason = None;
             recovery_outcome = None;
         } else if stream_finished {
@@ -314,6 +321,7 @@ pub(super) async fn collect_gemini_stream(
                 StreamRecoveryDecision::Cancelled => {
                     response_status = String::from("cancelled");
                     tool_calls.clear();
+                    signature_parts.clear();
                     interruption_reason = None;
                     recovery_outcome = None;
                 }
@@ -344,6 +352,7 @@ pub(super) async fn collect_gemini_stream(
                         Err(_wait_error) if cancel_token.is_cancelled() => {
                             response_status = String::from("cancelled");
                             tool_calls.clear();
+                            signature_parts.clear();
                             interruption_reason = None;
                             recovery_outcome = None;
                         }
@@ -357,6 +366,7 @@ pub(super) async fn collect_gemini_stream(
                     recovery_outcome = decision.recovery_outcome();
                     if matches!(decision, StreamRecoveryDecision::SurfaceInterrupted) {
                         tool_calls.clear();
+                        signature_parts.clear();
                     }
                 }
             }
@@ -366,11 +376,14 @@ pub(super) async fn collect_gemini_stream(
         let thinking = thinking_chunks.join("").trim().to_string();
         let tool_calls_json =
             serde_json::to_string(&tool_calls).unwrap_or_else(|_| "[]".to_string());
+        let thinking_blocks_json =
+            serde_json::to_string(&signature_parts).unwrap_or_else(|_| "[]".to_string());
 
         return Ok(GeminiStreamResult {
             id: response_id,
             content,
             thinking,
+            thinking_blocks_json,
             model: response_model,
             status: response_status,
             interruption_reason,

--- a/native/src/api/interactions/event.rs
+++ b/native/src/api/interactions/event.rs
@@ -594,7 +594,14 @@ fn process_top_level_delta(
     tool_calls: &mut InteractionsToolCallState,
     tool_args_delta: &mut String,
 ) {
-    let Some(delta) = event.get("delta") else {
+    // CLIProxyAPI has emitted both canonical top-level `delta` events and
+    // compatibility envelopes with the same delta nested below `step`.
+    // Treat both shapes identically; otherwise the step.start placeholder is
+    // finalized with `{}` while the real arguments fragment is discarded.
+    let delta = event
+        .get("delta")
+        .or_else(|| event.get("step").and_then(|step| step.get("delta")));
+    let Some(delta) = delta else {
         return;
     };
     process_delta_content(delta, "", content_chunks, thinking_chunks);
@@ -607,6 +614,12 @@ fn process_top_level_delta(
             .and_then(Value::as_str),
         _ => None,
     };
+    let index = index.or_else(|| {
+        event
+            .get("step")
+            .and_then(|step| step.get("index"))
+            .and_then(Value::as_u64)
+    });
     if let (Some(index), Some(fragment)) = (index, fragment) {
         tool_args_delta.push_str(fragment);
         tool_calls.append_arguments(index, fragment);
@@ -1181,6 +1194,33 @@ data: {"event_type":"interaction.completed","interaction":{"status":"completed"}
         assert_eq!(
             harness.calls.finalized_tool_calls()[0]["arguments"],
             json!({"filePath": "D:/Desktop/code/package.json"})
+        );
+    }
+
+    #[test]
+    fn reconstructs_arguments_from_nested_step_delta_envelope() {
+        let mut harness = Harness::default();
+        harness.process(
+            r#"event: step.start
+data: {"event_type":"step.start","index":0,"step":{"type":"function_call","id":"call_nested","name":"bash-terminal-execute","arguments":{}}}"#,
+        );
+        harness.process(
+            r#"event: step.delta
+data: {"event_type":"step.delta","step":{"index":0,"delta":{"type":"arguments_delta","arguments":"{\"command\":\"git status --short\"}"}}}"#,
+        );
+        harness.process(
+            r#"event: step.stop
+data: {"event_type":"step.stop","index":0}"#,
+        );
+        harness.process(
+            r#"event: interaction.completed
+data: {"event_type":"interaction.completed","interaction":{"status":"completed"}}"#,
+        );
+
+        assert_eq!(harness.status, "completed");
+        assert_eq!(
+            harness.calls.finalized_tool_calls()[0]["arguments"],
+            json!({"command": "git status --short"})
         );
     }
 

--- a/native/src/api/interactions/event.rs
+++ b/native/src/api/interactions/event.rs
@@ -1,0 +1,1596 @@
+//! Google Interactions API SSE event parsing and stream processing.
+
+use std::collections::BTreeMap;
+
+use regex::Regex;
+use serde_json::{json, Value};
+
+use crate::api::common::{read_first_i64, truncate_utf8_safe};
+use crate::storage::services::chat_conversations::ChatTokenUsage;
+
+const MAX_PROVIDER_FAILURE_CODE_BYTES: usize = 128;
+const MAX_PROVIDER_FAILURE_MESSAGE_BYTES: usize = 768;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct InteractionsProviderFailure {
+    code: Option<String>,
+    message: String,
+}
+
+impl InteractionsProviderFailure {
+    fn from_error_event(event: &Value) -> Self {
+        let error = event.get("error").unwrap_or(event);
+        let code = error
+            .get("code")
+            .and_then(provider_error_code)
+            .map(|value| bounded_provider_detail(&value, MAX_PROVIDER_FAILURE_CODE_BYTES))
+            .filter(|value| !value.is_empty());
+        let message = error
+            .get("message")
+            .or_else(|| event.get("message"))
+            .and_then(Value::as_str)
+            .map(|value| bounded_provider_detail(value, MAX_PROVIDER_FAILURE_MESSAGE_BYTES))
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| String::from("Interactions API request failed"));
+        Self { code, message }
+    }
+
+    fn failed_status() -> Self {
+        Self {
+            code: None,
+            message: String::from("Interactions API interaction failed"),
+        }
+    }
+
+    fn from_terminal_event(event: &Value, interaction: &Value) -> Self {
+        if event
+            .get("error")
+            .is_some_and(|provider_error| !provider_error.is_null())
+            || event.get("message").and_then(Value::as_str).is_some()
+        {
+            return Self::from_error_event(event);
+        }
+        if interaction
+            .get("error")
+            .is_some_and(|provider_error| !provider_error.is_null())
+            || interaction.get("message").and_then(Value::as_str).is_some()
+        {
+            return Self::from_error_event(interaction);
+        }
+        Self::failed_status()
+    }
+
+    fn invalid_tool_arguments() -> Self {
+        Self {
+            code: None,
+            message: String::from(
+                "Interactions API stream ended with incomplete or invalid tool arguments",
+            ),
+        }
+    }
+
+    pub(super) fn reason(&self) -> String {
+        match self.code.as_deref() {
+            Some(code) => format!("Interactions API error ({code}): {}", self.message),
+            None => self.message.clone(),
+        }
+    }
+}
+
+fn provider_error_code(value: &Value) -> Option<String> {
+    match value {
+        Value::String(code) => Some(code.clone()),
+        Value::Number(code) => Some(code.to_string()),
+        _ => None,
+    }
+}
+
+fn bounded_provider_detail(value: &str, max_bytes: usize) -> String {
+    let normalized = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    let redacted = redact_provider_detail(&normalized);
+    if redacted.len() <= max_bytes {
+        return redacted;
+    }
+    let visible = truncate_utf8_safe(&redacted, max_bytes.saturating_sub(3));
+    format!("{visible}...")
+}
+
+fn redact_provider_detail(value: &str) -> String {
+    const PATTERNS: &[(&str, &str)] = &[
+        (
+            r"(?i)\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{4,}",
+            "${1} [REDACTED]",
+        ),
+        (
+            r#"(?i)([?&](?:api[_-]?key|key|token|access[_-]?token|refresh[_-]?token|secret|password|authorization|signature)=)[^&\s\"'<>]+"#,
+            "${1}[REDACTED]",
+        ),
+        (
+            r#"(?i)([\"']?(?:api[_-]?key|token|access[_-]?token|refresh[_-]?token|secret|password|authorization|cookie)[\"']?\s*[:=]\s*[\"'])([^\"']*)([\"'])"#,
+            "${1}[REDACTED]${3}",
+        ),
+        (
+            r#"(?i)(\b(?:api[_-]?key|token|access[_-]?token|refresh[_-]?token|secret|password|authorization|cookie)\b\s*[:=]\s*)[^\s,;&}\]\"'\[]+"#,
+            "${1}[REDACTED]",
+        ),
+        (
+            r#"(?i)((?:^|[,{;]\s*)[\"']?(?:prompt|input|contents?)[\"']?\s*[:=]\s*[\"'])([^\"']*)([\"'])"#,
+            "${1}[REDACTED]${3}",
+        ),
+        (
+            r#"(?i)((?:^|[,{;]\s*)[\"']?(?:prompt|input|contents?)[\"']?\s*[:=]\s*)[^,;}\]\"'\[]+"#,
+            "${1}[REDACTED]",
+        ),
+    ];
+
+    PATTERNS
+        .iter()
+        .fold(value.to_string(), |redacted, (pattern, replacement)| {
+            Regex::new(pattern)
+                .expect("provider redaction regex")
+                .replace_all(&redacted, *replacement)
+                .into_owned()
+        })
+}
+
+pub(super) fn bounded_provider_error_response(value: &str) -> String {
+    if let Ok(event) = serde_json::from_str::<Value>(value) {
+        return InteractionsProviderFailure::from_error_event(&event).reason();
+    }
+
+    let detail = bounded_provider_detail(value, MAX_PROVIDER_FAILURE_MESSAGE_BYTES);
+    if detail.is_empty() {
+        String::from("Interactions API request failed")
+    } else {
+        detail
+    }
+}
+
+#[derive(Debug, Default)]
+pub(super) struct InteractionsToolCallState {
+    pending_by_index: BTreeMap<u64, PendingToolCall>,
+    finalized_by_index: BTreeMap<u64, Value>,
+    direct_calls: Vec<Value>,
+}
+
+#[derive(Debug, Default)]
+struct PendingToolCall {
+    metadata: Option<Value>,
+    raw_arguments: String,
+    arguments_object: Option<Value>,
+    stop_arguments_object: Option<Value>,
+    saw_empty_arguments_object: bool,
+    invalid_arguments: bool,
+    stopped: bool,
+}
+
+impl InteractionsToolCallState {
+    pub(super) fn has_tool_state(&self) -> bool {
+        !self.pending_by_index.is_empty()
+            || !self.finalized_by_index.is_empty()
+            || !self.direct_calls.is_empty()
+    }
+
+    pub(super) fn has_pending_tool_fragments(&self) -> bool {
+        !self.pending_by_index.is_empty()
+    }
+
+    pub(super) fn clear(&mut self) {
+        self.pending_by_index.clear();
+        self.finalized_by_index.clear();
+        self.direct_calls.clear();
+    }
+
+    pub(super) fn finalized_tool_calls(&self) -> Vec<Value> {
+        let mut calls = self
+            .finalized_by_index
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        for direct in &self.direct_calls {
+            if !calls
+                .iter()
+                .any(|call| same_tool_call_identity(call, direct))
+            {
+                calls.push(direct.clone());
+            }
+        }
+        calls
+    }
+
+    fn register_step(&mut self, index: u64, step: &Value, stopped: bool) {
+        if !is_function_call(step) && !self.pending_by_index.contains_key(&index) {
+            return;
+        }
+        let pending = self.pending_by_index.entry(index).or_default();
+        if is_function_call(step) {
+            if let Some(metadata) = pending.metadata.as_mut() {
+                merge_tool_call_values(metadata, step);
+            } else {
+                pending.metadata = Some(step.clone());
+            }
+            observe_arguments(pending, step, stopped);
+        }
+        pending.stopped |= stopped;
+        self.try_finalize(index);
+    }
+
+    fn append_arguments(&mut self, index: u64, fragment: &str) {
+        if !fragment.is_empty() {
+            self.pending_by_index
+                .entry(index)
+                .or_default()
+                .raw_arguments
+                .push_str(fragment);
+        }
+    }
+
+    fn stop_index(&mut self, index: u64) {
+        let Some(pending) = self.pending_by_index.get_mut(&index) else {
+            return;
+        };
+        pending.stopped = true;
+        self.try_finalize(index);
+    }
+
+    fn add_complete_indexed_call(&mut self, index: u64, call: &Value) {
+        if let Some(call) = materialize_complete_call(call) {
+            self.pending_by_index.remove(&index);
+            self.store_finalized_index(index, call);
+        } else if is_function_call(call) {
+            self.register_step(index, call, true);
+        }
+    }
+
+    fn add_complete_direct_call(&mut self, call: &Value) {
+        let Some(call) = materialize_complete_call(call) else {
+            return;
+        };
+        if let Some(existing) = self
+            .direct_calls
+            .iter_mut()
+            .find(|existing| same_tool_call_identity(existing, &call))
+        {
+            update_finalized_call(existing, call);
+        } else {
+            self.direct_calls.push(call);
+        }
+    }
+
+    fn try_finalize(&mut self, index: u64) {
+        let call = self
+            .pending_by_index
+            .get(&index)
+            .and_then(materialize_pending_call);
+        if let Some(call) = call {
+            self.pending_by_index.remove(&index);
+            self.store_finalized_index(index, call);
+        }
+    }
+
+    fn store_finalized_index(&mut self, index: u64, call: Value) {
+        if let Some(existing) = self.finalized_by_index.get_mut(&index) {
+            update_finalized_call(existing, call);
+        } else {
+            self.finalized_by_index.insert(index, call);
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn process_interactions_sse_event_block(
+    event_block: &str,
+    raw_events: &mut Vec<Value>,
+    content_chunks: &mut Vec<String>,
+    thinking_chunks: &mut Vec<String>,
+    tool_calls: &mut InteractionsToolCallState,
+    response_id: &mut String,
+    response_model: &mut String,
+    response_status: &mut String,
+    token_usage: &mut ChatTokenUsage,
+    tool_args_delta: &mut String,
+    stream_finished: &mut bool,
+    provider_failure: &mut Option<InteractionsProviderFailure>,
+) {
+    let mut found_data = false;
+    let mut sse_event_name: Option<String> = None;
+
+    for line in event_block.lines() {
+        let trimmed = line.trim_start();
+        if let Some(name) = trimmed.strip_prefix("event:") {
+            sse_event_name = Some(name.trim().to_string());
+            continue;
+        }
+        let Some(data) = trimmed.strip_prefix("data:") else {
+            continue;
+        };
+        found_data = true;
+        let data = data.trim_start();
+        if data.is_empty() {
+            continue;
+        }
+        if data == "[DONE]" {
+            if let Some(failure) = finish_interaction(
+                tool_calls,
+                response_status,
+                stream_finished,
+                "completed",
+                None,
+            ) {
+                *provider_failure = Some(failure);
+            }
+            return;
+        }
+
+        let event = match serde_json::from_str::<Value>(data) {
+            Ok(event) => event,
+            Err(error) => {
+                eprintln!("Interactions stream event parse error: {error}");
+                continue;
+            }
+        };
+        let result = process_interactions_event(
+            &event,
+            sse_event_name.as_deref(),
+            content_chunks,
+            thinking_chunks,
+            tool_calls,
+            response_id,
+            response_model,
+            response_status,
+            token_usage,
+            tool_args_delta,
+            stream_finished,
+        );
+        if let Err(failure) = result {
+            *response_status = String::from("failed");
+            *stream_finished = true;
+            tool_calls.clear();
+            *provider_failure = Some(failure);
+            return;
+        }
+        raw_events.push(event);
+        if *stream_finished {
+            return;
+        }
+    }
+
+    if found_data {
+        return;
+    }
+    let data = event_block.trim();
+    if data.is_empty() || data.starts_with(':') {
+        return;
+    }
+    if let Ok(event) = serde_json::from_str::<Value>(data) {
+        let result = process_interactions_event(
+            &event,
+            None,
+            content_chunks,
+            thinking_chunks,
+            tool_calls,
+            response_id,
+            response_model,
+            response_status,
+            token_usage,
+            tool_args_delta,
+            stream_finished,
+        );
+        if let Err(failure) = result {
+            *response_status = String::from("failed");
+            *stream_finished = true;
+            tool_calls.clear();
+            *provider_failure = Some(failure);
+            return;
+        }
+        raw_events.push(event);
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn process_interactions_event(
+    event: &Value,
+    sse_event_name: Option<&str>,
+    content_chunks: &mut Vec<String>,
+    thinking_chunks: &mut Vec<String>,
+    tool_calls: &mut InteractionsToolCallState,
+    response_id: &mut String,
+    response_model: &mut String,
+    response_status: &mut String,
+    token_usage: &mut ChatTokenUsage,
+    tool_args_delta: &mut String,
+    stream_finished: &mut bool,
+) -> std::result::Result<(), InteractionsProviderFailure> {
+    let interaction = event.get("interaction").unwrap_or(event);
+    capture_metadata(event, interaction, response_id, response_model);
+    if let Some(usage) = event
+        .get("usage_metadata")
+        .or_else(|| event.get("usage"))
+        .or_else(|| interaction.get("usage_metadata"))
+        .or_else(|| interaction.get("usage"))
+    {
+        extract_interactions_token_usage(usage, token_usage);
+    }
+
+    let event_type = event_type(event, sse_event_name);
+    if event_type == Some("error")
+        || event
+            .get("error")
+            .is_some_and(|provider_error| !provider_error.is_null())
+    {
+        return Err(InteractionsProviderFailure::from_error_event(event));
+    }
+    let index = event.get("index").and_then(Value::as_u64);
+    match event_type {
+        Some("step.start") => {
+            if let Some(step) = event.get("step") {
+                process_step_content(step, content_chunks, thinking_chunks);
+                if let Some(index) = index {
+                    tool_calls.register_step(index, step, false);
+                }
+            }
+        }
+        Some("step.delta") => process_top_level_delta(
+            event,
+            index,
+            content_chunks,
+            thinking_chunks,
+            tool_calls,
+            tool_args_delta,
+        ),
+        Some("step.stop") | Some("step.completed") => {
+            if let Some(step) = event.get("step") {
+                process_step_content(step, content_chunks, thinking_chunks);
+                if let Some(index) = index {
+                    tool_calls.register_step(index, step, true);
+                } else {
+                    process_complete_calls(step, tool_calls);
+                }
+            } else if let Some(index) = index {
+                tool_calls.stop_index(index);
+            }
+        }
+        _ => process_compatibility_event(
+            event,
+            interaction,
+            content_chunks,
+            thinking_chunks,
+            tool_calls,
+            tool_args_delta,
+        ),
+    }
+
+    if let Some(status) = interaction_terminal(event, interaction, sse_event_name) {
+        let terminal_failure = (status == "failed")
+            .then(|| InteractionsProviderFailure::from_terminal_event(event, interaction));
+        if let Some(failure) = finish_interaction(
+            tool_calls,
+            response_status,
+            stream_finished,
+            status,
+            terminal_failure,
+        ) {
+            return Err(failure);
+        }
+    }
+    Ok(())
+}
+
+fn event_type<'a>(event: &'a Value, sse_event_name: Option<&'a str>) -> Option<&'a str> {
+    event
+        .get("event_type")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            event.get("type").and_then(Value::as_str).filter(|value| {
+                value.starts_with("step.") || value.starts_with("interaction.") || *value == "error"
+            })
+        })
+        .or(sse_event_name)
+}
+
+fn terminal_status(status: Option<&str>) -> Option<&str> {
+    match status {
+        Some("completed") | Some("succeeded") | Some("finished") | Some("requires_action") => {
+            Some("completed")
+        }
+        Some("failed") | Some("error") => Some("failed"),
+        Some("cancelled") | Some("canceled") => Some("cancelled"),
+        _ => None,
+    }
+}
+
+fn interaction_terminal<'a>(
+    event: &'a Value,
+    interaction: &'a Value,
+    sse_event_name: Option<&'a str>,
+) -> Option<&'a str> {
+    match event_type(event, sse_event_name) {
+        Some("interaction.completed") | Some("completed") | Some("done") => {
+            return Some("completed")
+        }
+        Some("interaction.failed") | Some("interaction.error") => return Some("failed"),
+        Some("interaction.cancelled") | Some("interaction.canceled") => return Some("cancelled"),
+        _ => {}
+    }
+
+    if event_type(event, sse_event_name) == Some("interaction.status_update") {
+        if let Some(status) = terminal_status(event.get("status").and_then(Value::as_str)) {
+            return Some(status);
+        }
+    }
+
+    if event.get("interaction").is_none() && event.get("steps").is_none() {
+        return None;
+    }
+    terminal_status(interaction.get("status").and_then(Value::as_str))
+}
+
+fn finish_interaction(
+    tool_calls: &mut InteractionsToolCallState,
+    response_status: &mut String,
+    stream_finished: &mut bool,
+    status: &str,
+    provider_failure: Option<InteractionsProviderFailure>,
+) -> Option<InteractionsProviderFailure> {
+    let failure = match status {
+        "completed" if tool_calls.has_pending_tool_fragments() => {
+            // A terminal with malformed or unfinished arguments is a provider
+            // failure, never an executable empty-argument call.
+            *response_status = String::from("failed");
+            tool_calls.clear();
+            Some(InteractionsProviderFailure::invalid_tool_arguments())
+        }
+        "completed" => {
+            *response_status = String::from("completed");
+            None
+        }
+        "cancelled" => {
+            *response_status = String::from("cancelled");
+            tool_calls.clear();
+            None
+        }
+        _ => {
+            *response_status = String::from("failed");
+            tool_calls.clear();
+            Some(provider_failure.unwrap_or_else(InteractionsProviderFailure::failed_status))
+        }
+    };
+    *stream_finished = true;
+    failure
+}
+
+fn capture_metadata(
+    event: &Value,
+    interaction: &Value,
+    response_id: &mut String,
+    response_model: &mut String,
+) {
+    if response_id.is_empty() {
+        if let Some(id) = event
+            .get("interaction_id")
+            .or_else(|| interaction.get("id"))
+            .or_else(|| event.get("id"))
+            .and_then(Value::as_str)
+        {
+            *response_id = id.to_string();
+        }
+    }
+    if response_model.is_empty() {
+        if let Some(model) = event
+            .get("model")
+            .or_else(|| interaction.get("model"))
+            .and_then(Value::as_str)
+        {
+            *response_model = model.to_string();
+        }
+    }
+}
+
+fn process_top_level_delta(
+    event: &Value,
+    index: Option<u64>,
+    content_chunks: &mut Vec<String>,
+    thinking_chunks: &mut Vec<String>,
+    tool_calls: &mut InteractionsToolCallState,
+    tool_args_delta: &mut String,
+) {
+    let Some(delta) = event.get("delta") else {
+        return;
+    };
+    process_delta_content(delta, "", content_chunks, thinking_chunks);
+
+    let fragment = match delta.get("type").and_then(Value::as_str).unwrap_or("") {
+        "arguments_delta" => delta.get("arguments").and_then(Value::as_str),
+        "arguments" => delta
+            .get("partial_arguments")
+            .or_else(|| delta.get("arguments"))
+            .and_then(Value::as_str),
+        _ => None,
+    };
+    if let (Some(index), Some(fragment)) = (index, fragment) {
+        tool_args_delta.push_str(fragment);
+        tool_calls.append_arguments(index, fragment);
+    }
+}
+
+fn process_compatibility_event(
+    event: &Value,
+    interaction: &Value,
+    content_chunks: &mut Vec<String>,
+    thinking_chunks: &mut Vec<String>,
+    tool_calls: &mut InteractionsToolCallState,
+    tool_args_delta: &mut String,
+) {
+    if let Some(step) = event.get("step") {
+        process_step_content(step, content_chunks, thinking_chunks);
+        if let Some(index) = event.get("index").and_then(Value::as_u64) {
+            if let Some(fragment) = step
+                .get("delta")
+                .and_then(|delta| {
+                    delta
+                        .get("arguments")
+                        .or_else(|| delta.get("partial_arguments"))
+                        .or_else(|| delta.get("args"))
+                })
+                .and_then(Value::as_str)
+            {
+                tool_args_delta.push_str(fragment);
+                tool_calls.append_arguments(index, fragment);
+            }
+            let stopped = step_is_complete(step);
+            tool_calls.register_step(index, step, stopped);
+        } else if step_is_complete(step) {
+            process_complete_calls(step, tool_calls);
+        }
+    } else if let Some(delta) = event.get("delta") {
+        process_delta_content(delta, "", content_chunks, thinking_chunks);
+    } else if let Some(text) = event.get("text").and_then(Value::as_str) {
+        if !text.is_empty() {
+            content_chunks.push(text.to_string());
+        }
+    }
+
+    process_steps_array(event, content_chunks, thinking_chunks, tool_calls);
+    if event.get("interaction").is_some() {
+        process_steps_array(interaction, content_chunks, thinking_chunks, tool_calls);
+    }
+    process_complete_calls(event, tool_calls);
+}
+
+fn step_is_complete(step: &Value) -> bool {
+    step.get("status")
+        .and_then(Value::as_str)
+        .is_some_and(|status| matches!(status, "completed" | "succeeded" | "finished"))
+        || step
+            .get("finish_reason")
+            .or_else(|| step.get("finishReason"))
+            .and_then(Value::as_str)
+            .is_some_and(|reason| !reason.is_empty())
+}
+
+fn process_steps_array(
+    value: &Value,
+    content_chunks: &mut Vec<String>,
+    thinking_chunks: &mut Vec<String>,
+    tool_calls: &mut InteractionsToolCallState,
+) {
+    let Some(steps) = value.get("steps").and_then(Value::as_array) else {
+        return;
+    };
+    for (position, step) in steps.iter().enumerate() {
+        process_step_content(step, content_chunks, thinking_chunks);
+        if is_function_call(step) {
+            let index = step
+                .get("index")
+                .and_then(Value::as_u64)
+                .unwrap_or(position as u64);
+            tool_calls.add_complete_indexed_call(index, step);
+        }
+    }
+}
+
+fn process_step_content(
+    step: &Value,
+    content_chunks: &mut Vec<String>,
+    thinking_chunks: &mut Vec<String>,
+) {
+    let step_type = step.get("type").and_then(Value::as_str).unwrap_or("");
+    if let Some(delta) = step.get("delta") {
+        process_delta_content(delta, step_type, content_chunks, thinking_chunks);
+    }
+    if let Some(text) = step.get("text").and_then(Value::as_str) {
+        push_text(text, step_type, content_chunks, thinking_chunks);
+    }
+    if let Some(thought) = step.get("thought").and_then(Value::as_str) {
+        if !thought.is_empty() {
+            thinking_chunks.push(thought.to_string());
+        }
+    }
+}
+
+fn process_delta_content(
+    delta: &Value,
+    step_type: &str,
+    content_chunks: &mut Vec<String>,
+    thinking_chunks: &mut Vec<String>,
+) {
+    let delta_type = delta.get("type").and_then(Value::as_str).unwrap_or("");
+    let effective_step_type = if matches!(delta_type, "thought_summary" | "thought" | "thinking") {
+        "thought"
+    } else {
+        step_type
+    };
+    if let Some(text) = delta.get("text").and_then(Value::as_str).or_else(|| {
+        delta
+            .get("content")
+            .and_then(|content| content.get("text"))
+            .and_then(Value::as_str)
+    }) {
+        push_text(text, effective_step_type, content_chunks, thinking_chunks);
+    }
+    if let Some(thought) = delta.get("thought").and_then(Value::as_str) {
+        if !thought.is_empty() {
+            thinking_chunks.push(thought.to_string());
+        }
+    }
+}
+
+fn push_text(
+    text: &str,
+    step_type: &str,
+    content_chunks: &mut Vec<String>,
+    thinking_chunks: &mut Vec<String>,
+) {
+    if text.is_empty() {
+        return;
+    }
+    if matches!(step_type, "thought" | "thinking") {
+        thinking_chunks.push(text.to_string());
+    } else {
+        content_chunks.push(text.to_string());
+    }
+}
+
+fn process_complete_calls(value: &Value, tool_calls: &mut InteractionsToolCallState) {
+    if is_function_call(value) {
+        tool_calls.add_complete_direct_call(value);
+    }
+    if let Some(call) = value
+        .get("tool_call")
+        .or_else(|| value.get("function_call"))
+        .or_else(|| value.get("functionCall"))
+    {
+        tool_calls.add_complete_direct_call(call);
+    }
+    if let Some(calls) = value.get("tool_calls").and_then(Value::as_array) {
+        for call in calls {
+            tool_calls.add_complete_direct_call(call);
+        }
+    }
+    if let Some(candidates) = value.get("candidates").and_then(Value::as_array) {
+        for candidate in candidates {
+            let Some(parts) = candidate
+                .get("content")
+                .and_then(|content| content.get("parts"))
+                .and_then(Value::as_array)
+            else {
+                continue;
+            };
+            for part in parts {
+                if let Some(call) = part
+                    .get("functionCall")
+                    .or_else(|| part.get("function_call"))
+                {
+                    tool_calls.add_complete_direct_call(call);
+                }
+            }
+        }
+    }
+}
+
+fn is_function_call(value: &Value) -> bool {
+    let value_type = value.get("type").and_then(Value::as_str).unwrap_or("");
+    matches!(value_type, "function_call" | "tool_call")
+        || (tool_call_name(value).is_some() && argument_value(value).is_some())
+}
+
+fn observe_arguments(pending: &mut PendingToolCall, call: &Value, stopped: bool) {
+    let Some(arguments) = argument_value(call) else {
+        return;
+    };
+    match arguments {
+        Value::Object(arguments) => {
+            if arguments.is_empty() {
+                pending.saw_empty_arguments_object = true;
+            } else {
+                pending.arguments_object = Some(Value::Object(arguments.clone()));
+            }
+            if stopped {
+                pending.stop_arguments_object = Some(Value::Object(arguments.clone()));
+            }
+        }
+        Value::String(arguments) => {
+            if !arguments.is_empty() {
+                pending.raw_arguments.push_str(arguments);
+            }
+        }
+        Value::Null => {}
+        _ => pending.invalid_arguments = true,
+    }
+}
+
+fn materialize_pending_call(pending: &PendingToolCall) -> Option<Value> {
+    if !pending.stopped || pending.invalid_arguments {
+        return None;
+    }
+    let metadata = pending.metadata.as_ref()?;
+    let non_empty_stop_arguments = pending
+        .stop_arguments_object
+        .clone()
+        .filter(|arguments| arguments.as_object().is_some_and(|value| !value.is_empty()));
+    let arguments = if let Some(arguments) = non_empty_stop_arguments {
+        arguments
+    } else if !pending.raw_arguments.is_empty() {
+        parse_arguments_object(&pending.raw_arguments)?
+    } else if let Some(arguments) = pending.arguments_object.clone() {
+        arguments
+    } else if let Some(arguments) = pending.stop_arguments_object.clone() {
+        arguments
+    } else if pending.saw_empty_arguments_object {
+        json!({})
+    } else {
+        return None;
+    };
+    materialize_call(metadata, arguments)
+}
+
+fn materialize_complete_call(call: &Value) -> Option<Value> {
+    let arguments = match argument_value(call)? {
+        Value::Object(arguments) => Value::Object(arguments.clone()),
+        Value::String(arguments) => parse_arguments_object(arguments)?,
+        _ => return None,
+    };
+    materialize_call(call, arguments)
+}
+
+fn materialize_call(call: &Value, arguments: Value) -> Option<Value> {
+    if !arguments.is_object() {
+        return None;
+    }
+    let mut call = call.as_object().cloned()?;
+    let name = tool_call_name(&Value::Object(call.clone()))?.to_string();
+    call.insert(
+        "type".to_string(),
+        Value::String("function_call".to_string()),
+    );
+    call.insert("name".to_string(), Value::String(name));
+    call.insert("arguments".to_string(), arguments.clone());
+    call.insert("args".to_string(), arguments);
+    Some(Value::Object(call))
+}
+
+fn parse_arguments_object(raw: &str) -> Option<Value> {
+    let value = serde_json::from_str::<Value>(raw).ok()?;
+    value.is_object().then_some(value)
+}
+
+fn argument_value(value: &Value) -> Option<&Value> {
+    value
+        .get("arguments")
+        .or_else(|| value.get("args"))
+        .or_else(|| value.get("input"))
+        .or_else(|| {
+            value
+                .get("function")
+                .and_then(|function| function.get("arguments"))
+        })
+        .or_else(|| {
+            value
+                .get("function")
+                .and_then(|function| function.get("args"))
+        })
+        .or_else(|| {
+            value
+                .get("functionCall")
+                .and_then(|function| function.get("arguments"))
+        })
+        .or_else(|| {
+            value
+                .get("functionCall")
+                .and_then(|function| function.get("args"))
+        })
+        .or_else(|| {
+            value
+                .get("function_call")
+                .and_then(|function| function.get("arguments"))
+        })
+        .or_else(|| {
+            value
+                .get("function_call")
+                .and_then(|function| function.get("args"))
+        })
+}
+
+fn tool_call_id(value: &Value) -> Option<&str> {
+    value
+        .get("id")
+        .or_else(|| value.get("call_id"))
+        .or_else(|| value.get("callId"))
+        .and_then(Value::as_str)
+        .filter(|id| !id.is_empty())
+}
+
+fn tool_call_name(value: &Value) -> Option<&str> {
+    value
+        .get("name")
+        .or_else(|| {
+            value
+                .get("function")
+                .and_then(|function| function.get("name"))
+        })
+        .or_else(|| {
+            value
+                .get("functionCall")
+                .and_then(|function| function.get("name"))
+        })
+        .or_else(|| {
+            value
+                .get("function_call")
+                .and_then(|function| function.get("name"))
+        })
+        .and_then(Value::as_str)
+        .filter(|name| !name.is_empty())
+}
+
+fn same_tool_call_identity(left: &Value, right: &Value) -> bool {
+    match (tool_call_id(left), tool_call_id(right)) {
+        (Some(left_id), Some(right_id)) => left_id == right_id,
+        (Some(_), None) | (None, Some(_)) => false,
+        (None, None) => {
+            tool_call_name(left).is_some() && tool_call_name(left) == tool_call_name(right)
+        }
+    }
+}
+
+fn merge_tool_call_values(target: &mut Value, incoming: &Value) {
+    let Some(target) = target.as_object_mut() else {
+        *target = incoming.clone();
+        return;
+    };
+    let Some(incoming) = incoming.as_object() else {
+        return;
+    };
+    for (key, value) in incoming {
+        if key != "arguments" && key != "args" && !value.is_null() {
+            target.insert(key.clone(), value.clone());
+        }
+    }
+}
+
+fn update_finalized_call(existing: &mut Value, incoming: Value) {
+    let existing_has_arguments = argument_value(existing)
+        .and_then(Value::as_object)
+        .is_some_and(|arguments| !arguments.is_empty());
+    let incoming_has_empty_arguments = argument_value(&incoming)
+        .and_then(Value::as_object)
+        .is_some_and(serde_json::Map::is_empty);
+    if existing_has_arguments && incoming_has_empty_arguments {
+        merge_tool_call_values(existing, &incoming);
+    } else {
+        *existing = incoming;
+    }
+}
+
+fn extract_interactions_token_usage(usage: &Value, token_usage: &mut ChatTokenUsage) {
+    let prompt = read_first_i64(
+        usage,
+        &[
+            &["total_input_tokens"],
+            &["prompt_token_count"],
+            &["prompt_tokens"],
+            &["input_tokens"],
+        ],
+    );
+    if prompt > 0 {
+        token_usage.input_tokens = prompt;
+    }
+    let mut candidates = read_first_i64(
+        usage,
+        &[
+            &["total_output_tokens"],
+            &["candidates_token_count"],
+            &["completion_tokens"],
+            &["output_tokens"],
+        ],
+    );
+    // CLIProxyAPI reports thought and tool-use tokens separately from
+    // total_output_tokens. Snow has no dedicated reasoning-token field, so
+    // fold them into output usage to preserve the provider's total usage.
+    if usage.get("total_output_tokens").is_some() {
+        candidates += read_first_i64(usage, &[&["total_thought_tokens"]]);
+        candidates += read_first_i64(usage, &[&["total_tool_use_tokens"]]);
+    }
+    if candidates > 0 {
+        token_usage.output_tokens = candidates;
+    }
+    let cached = read_first_i64(
+        usage,
+        &[
+            &["total_cached_tokens"],
+            &["cached_content_token_count"],
+            &["cachedContentTokenCount"],
+            &["cache_read_input_tokens"],
+        ],
+    );
+    if cached > 0 {
+        token_usage.cache_read_input_tokens = cached;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Harness {
+        raw: Vec<Value>,
+        content: Vec<String>,
+        thinking: Vec<String>,
+        calls: InteractionsToolCallState,
+        id: String,
+        model: String,
+        status: String,
+        usage: ChatTokenUsage,
+        args_delta: String,
+        finished: bool,
+        failure: Option<InteractionsProviderFailure>,
+    }
+
+    impl Default for Harness {
+        fn default() -> Self {
+            Self {
+                raw: Vec::new(),
+                content: Vec::new(),
+                thinking: Vec::new(),
+                calls: InteractionsToolCallState::default(),
+                id: String::new(),
+                model: String::new(),
+                status: String::from("in_progress"),
+                usage: ChatTokenUsage::default(),
+                args_delta: String::new(),
+                finished: false,
+                failure: None,
+            }
+        }
+    }
+
+    impl Harness {
+        fn process(&mut self, block: &str) {
+            self.args_delta.clear();
+            process_interactions_sse_event_block(
+                block,
+                &mut self.raw,
+                &mut self.content,
+                &mut self.thinking,
+                &mut self.calls,
+                &mut self.id,
+                &mut self.model,
+                &mut self.status,
+                &mut self.usage,
+                &mut self.args_delta,
+                &mut self.finished,
+                &mut self.failure,
+            );
+        }
+    }
+
+    #[test]
+    fn parses_text_thought_metadata_and_usage() {
+        let mut harness = Harness::default();
+        harness.process(
+            r#"data: {"id":"inter_1","model":"gemini-test","step":{"type":"text","delta":{"text":"hello","thought":"plan"}},"usage":{"input_tokens":2,"output_tokens":3}}"#,
+        );
+        assert_eq!(harness.id, "inter_1");
+        assert_eq!(harness.model, "gemini-test");
+        assert_eq!(harness.content, ["hello"]);
+        assert_eq!(harness.thinking, ["plan"]);
+        assert_eq!(harness.usage.input_tokens, 2);
+        assert_eq!(harness.usage.output_tokens, 3);
+    }
+
+    #[test]
+    fn parses_cli_proxy_nested_thought_summary_without_mixing_answer_text() {
+        let mut harness = Harness::default();
+        harness.process(
+            r#"event: step.start
+data: {"event_type":"step.start","index":0,"step":{"type":"thought"}}"#,
+        );
+        harness.process(r#"event: step.delta
+data: {"event_type":"step.delta","index":0,"delta":{"content":{"text":"reasoning summary","type":"text"},"type":"thought_summary"}}"#);
+        harness.process(
+            r#"event: step.stop
+data: {"event_type":"step.stop","index":0}"#,
+        );
+        harness.process(
+            r#"event: step.start
+data: {"event_type":"step.start","index":1,"step":{"type":"model_output"}}"#,
+        );
+        harness.process(
+            r#"event: step.delta
+data: {"event_type":"step.delta","index":1,"delta":{"text":"answer","type":"text"}}"#,
+        );
+        harness.process(
+            r#"event: interaction.completed
+data: {"event_type":"interaction.completed","interaction":{"status":"completed"}}"#,
+        );
+
+        assert!(harness.finished);
+        assert_eq!(harness.status, "completed");
+        assert_eq!(harness.thinking, ["reasoning summary"]);
+        assert_eq!(harness.content, ["answer"]);
+    }
+
+    #[test]
+    fn parses_cli_proxy_completed_usage_totals() {
+        let mut harness = Harness::default();
+        harness.process(
+            r#"event: interaction.completed
+data: {"event_type":"interaction.completed","interaction":{"status":"completed","usage":{"input_tokens_by_modality":{"text":6},"total_cached_tokens":2,"total_input_tokens":6,"total_output_tokens":1,"total_thought_tokens":95,"total_tokens":104,"total_tool_use_tokens":2}}}"#,
+        );
+
+        assert!(harness.finished);
+        assert_eq!(harness.status, "completed");
+        assert_eq!(harness.usage.input_tokens, 6);
+        assert_eq!(harness.usage.output_tokens, 98);
+        assert_eq!(harness.usage.cache_read_input_tokens, 2);
+        assert_eq!(harness.usage.cache_creation_input_tokens, 0);
+    }
+
+    #[test]
+    fn preserves_legacy_interactions_usage_aliases() {
+        let mut harness = Harness::default();
+        harness.process(
+            r#"data: {"event_type":"interaction.completed","interaction":{"status":"completed","usage":{"prompt_tokens":7,"completion_tokens":3,"cache_read_input_tokens":1}}}"#,
+        );
+
+        assert_eq!(harness.usage.input_tokens, 7);
+        assert_eq!(harness.usage.output_tokens, 3);
+        assert_eq!(harness.usage.cache_read_input_tokens, 1);
+    }
+
+    #[test]
+    fn reconstructs_canonical_split_arguments() {
+        let mut harness = Harness::default();
+        harness.process(r#"event: step.start
+data: {"event_type":"step.start","index":0,"step":{"type":"function_call","id":"call_1","name":"filesystem-read","arguments":{}}}"#);
+        harness.process(r#"event: step.delta
+data: {"event_type":"step.delta","index":0,"delta":{"type":"arguments_delta","arguments":"{\"filePath\":\"D:/Desktop/"}}"#);
+        assert_eq!(harness.args_delta, r#"{"filePath":"D:/Desktop/"#);
+        harness.process(r#"event: step.delta
+data: {"event_type":"step.delta","index":0,"delta":{"type":"arguments_delta","arguments":"code/package.json\"}"}}"#);
+        harness.process(
+            r#"event: step.stop
+data: {"event_type":"step.stop","index":0}"#,
+        );
+        harness.process(
+            r#"event: interaction.completed
+data: {"event_type":"interaction.completed","interaction":{"status":"completed"}}"#,
+        );
+
+        assert!(harness.finished);
+        assert_eq!(harness.status, "completed");
+        assert_eq!(
+            harness.calls.finalized_tool_calls()[0]["arguments"],
+            json!({"filePath": "D:/Desktop/code/package.json"})
+        );
+    }
+
+    #[test]
+    fn accumulated_arguments_override_repeated_stop_placeholder() {
+        let mut harness = Harness::default();
+        harness.process(r#"data: {"event_type":"step.start","index":0,"step":{"type":"function_call","id":"call_1","name":"filesystem-read","arguments":{}}}"#);
+        harness.process(r#"data: {"event_type":"step.delta","index":0,"delta":{"type":"arguments_delta","arguments":"{\"filePath\":\"package.json\"}"}}"#);
+        harness.process(r#"data: {"event_type":"step.stop","index":0,"step":{"type":"function_call","id":"call_1","name":"filesystem-read","arguments":{}}}"#);
+        harness.process(
+            r#"data: {"event_type":"interaction.completed","interaction":{"status":"completed"}}"#,
+        );
+
+        let calls = harness.calls.finalized_tool_calls();
+        assert_eq!(harness.status, "completed");
+        assert_eq!(calls[0]["arguments"], json!({"filePath": "package.json"}));
+    }
+
+    #[test]
+    fn repeated_empty_completed_step_does_not_erase_finalized_arguments() {
+        let mut harness = Harness::default();
+        harness.process(r#"data: {"event_type":"step.start","index":0,"step":{"type":"function_call","id":"call_1","name":"filesystem-read","arguments":{}}}"#);
+        harness.process(r#"data: {"event_type":"step.delta","index":0,"delta":{"type":"arguments_delta","arguments":"{\"filePath\":\"package.json\"}"}}"#);
+        harness.process(r#"data: {"event_type":"step.stop","index":0}"#);
+        harness.process(r#"data: {"event_type":"step.completed","index":0,"step":{"type":"function_call","id":"call_1","name":"filesystem-read","arguments":{},"status":"completed"}}"#);
+
+        let calls = harness.calls.finalized_tool_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0]["arguments"], json!({"filePath": "package.json"}));
+        assert!(!harness.calls.has_pending_tool_fragments());
+    }
+
+    #[test]
+    fn complete_compatibility_step_applies_nested_delta_before_finalization() {
+        let mut harness = Harness::default();
+        harness.process(r#"data: {"index":2,"step":{"type":"function_call","id":"call_compat","name":"filesystem-read","arguments":{},"delta":{"arguments":"{\"filePath\":\"package.json\"}"},"status":"completed"}}"#);
+
+        let calls = harness.calls.finalized_tool_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0]["id"], "call_compat");
+        assert_eq!(calls[0]["arguments"], json!({"filePath": "package.json"}));
+        assert!(!harness.calls.has_pending_tool_fragments());
+    }
+
+    #[test]
+    fn isolates_interleaved_indexes_and_supports_alias_delta() {
+        let mut harness = Harness::default();
+        harness.process(r#"data: {"event_type":"step.start","index":1,"step":{"type":"function_call","id":"call_todo","name":"todo-todo-manage","arguments":{}}}"#);
+        harness.process(r#"data: {"event_type":"step.start","index":0,"step":{"type":"function_call","id":"call_read","name":"filesystem-read","arguments":{}}}"#);
+        harness.process(r#"data: {"event_type":"step.delta","index":1,"delta":{"type":"arguments_delta","arguments":"{\"action\":\"get\"}"}}"#);
+        harness.process(r#"data: {"event_type":"step.delta","index":0,"delta":{"type":"arguments","partial_arguments":"{\"filePath\":\"package.json\"}"}}"#);
+        harness.process(r#"data: {"event_type":"step.stop","index":1}"#);
+        harness.process(r#"data: {"event_type":"step.stop","index":0}"#);
+
+        let calls = harness.calls.finalized_tool_calls();
+        assert_eq!(calls[0]["id"], "call_read");
+        assert_eq!(calls[0]["arguments"], json!({"filePath": "package.json"}));
+        assert_eq!(calls[1]["id"], "call_todo");
+        assert_eq!(calls[1]["arguments"], json!({"action": "get"}));
+    }
+
+    #[test]
+    fn retains_delta_before_start_for_stable_index() {
+        let mut harness = Harness::default();
+        harness.process(r#"data: {"event_type":"step.delta","index":4,"delta":{"type":"arguments_delta","arguments":"{\"action\":\"get\"}"}}"#);
+        harness.process(r#"data: {"event_type":"step.start","index":4,"step":{"type":"function_call","id":"call_late","name":"todo-todo-manage","arguments":{}}}"#);
+        harness.process(r#"data: {"event_type":"step.stop","index":4}"#);
+        assert_eq!(
+            harness.calls.finalized_tool_calls()[0]["arguments"],
+            json!({"action": "get"})
+        );
+    }
+
+    #[test]
+    fn step_completion_does_not_finish_the_interaction() {
+        let mut harness = Harness::default();
+        harness.process(r#"data: {"event_type":"step.start","index":0,"step":{"type":"function_call","id":"call_1","name":"filesystem-read","arguments":{}}}"#);
+        harness.process(r#"event: step.completed
+data: {"event_type":"step.completed","index":0,"step":{"type":"function_call","id":"call_1","name":"filesystem-read","arguments":{"filePath":"package.json"},"status":"completed"}}"#);
+        assert!(!harness.finished);
+        assert_eq!(harness.status, "in_progress");
+
+        harness.process(
+            r#"data: {"event_type":"step.start","index":1,"step":{"type":"text","text":"done"}}"#,
+        );
+        harness.process(
+            r#"data: {"event_type":"interaction.completed","interaction":{"status":"completed"}}"#,
+        );
+        assert!(harness.finished);
+        assert_eq!(harness.content, ["done"]);
+    }
+
+    #[test]
+    fn indexed_non_function_stop_without_step_does_not_create_tool_state() {
+        for event_type in ["step.stop", "step.completed"] {
+            let mut harness = Harness::default();
+            harness.process(
+                r#"data: {"event_type":"step.start","index":0,"step":{"type":"google_search","status":"in_progress"}}"#,
+            );
+            harness.process(&format!(
+                "data: {}",
+                json!({"event_type": event_type, "index": 0})
+            ));
+
+            assert!(!harness.calls.has_tool_state());
+            assert!(!harness.calls.has_pending_tool_fragments());
+
+            harness.process(
+                r#"data: {"event_type":"interaction.completed","interaction":{"status":"completed"}}"#,
+            );
+            assert!(harness.finished);
+            assert_eq!(harness.status, "completed");
+            assert!(harness.failure.is_none());
+        }
+    }
+
+    #[test]
+    fn malformed_truncated_and_non_object_arguments_never_execute() {
+        for arguments in [r#"{"filePath":"package.json"#, "[]"] {
+            let mut harness = Harness::default();
+            harness.process(r#"data: {"event_type":"step.start","index":0,"step":{"type":"function_call","id":"call_bad","name":"filesystem-read","arguments":{}}}"#);
+            let event = json!({
+                "event_type": "step.delta",
+                "index": 0,
+                "delta": {"type": "arguments_delta", "arguments": arguments}
+            });
+            harness.process(&format!("data: {event}"));
+            harness.process(r#"data: {"event_type":"step.stop","index":0}"#);
+            assert!(harness.calls.has_pending_tool_fragments());
+            assert!(harness.calls.finalized_tool_calls().is_empty());
+
+            harness.process(r#"data: {"event_type":"interaction.completed","interaction":{"status":"completed"}}"#);
+            assert_eq!(harness.status, "failed");
+            assert!(harness.calls.finalized_tool_calls().is_empty());
+        }
+    }
+
+    #[test]
+    fn missing_or_unknown_index_does_not_attach_to_last_call() {
+        let mut harness = Harness::default();
+        harness.process(r#"data: {"event_type":"step.start","index":0,"step":{"type":"function_call","id":"call_known","name":"filesystem-read","arguments":{}}}"#);
+        harness.process(r#"data: {"event_type":"step.delta","delta":{"type":"arguments_delta","arguments":"{\"filePath\":\"wrong\"}"}}"#);
+        harness.process(r#"data: {"event_type":"step.delta","index":9,"delta":{"type":"arguments_delta","arguments":"{\"filePath\":\"unknown\"}"}}"#);
+        harness.process(r#"data: {"event_type":"step.stop","index":0}"#);
+        let finalized = harness.calls.finalized_tool_calls();
+        assert_eq!(finalized.len(), 1);
+        assert_eq!(finalized[0]["id"], "call_known");
+        assert_eq!(finalized[0]["arguments"], json!({}));
+        assert!(harness.calls.has_pending_tool_fragments());
+    }
+
+    #[test]
+    fn parameterless_call_finalizes_with_empty_arguments() {
+        let mut harness = Harness::default();
+        harness.process(r#"data: {"event_type":"step.start","index":0,"step":{"type":"function_call","id":"call_ping","name":"system-ping","arguments":{}}}"#);
+        harness.process(r#"data: {"event_type":"step.stop","index":0}"#);
+        let calls = harness.calls.finalized_tool_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0]["arguments"], json!({}));
+    }
+
+    #[test]
+    fn direct_steps_and_provider_aliases_remain_supported() {
+        let mut harness = Harness::default();
+        harness.process(r#"data: {"event_type":"interaction.completed","interaction":{"id":"inter_direct","status":"completed","steps":[{"type":"function_call","id":"call_direct","name":"filesystem-read","arguments":{"filePath":"package.json"}}]}}"#);
+        assert_eq!(
+            harness.calls.finalized_tool_calls()[0]["arguments"],
+            json!({"filePath": "package.json"})
+        );
+
+        let mut alias_harness = Harness::default();
+        alias_harness.process(r#"data: {"functionCall":{"id":"call_alias","name":"config-get","args":{"action":"get"}}}"#);
+        assert_eq!(
+            alias_harness.calls.finalized_tool_calls()[0]["arguments"],
+            json!({"action": "get"})
+        );
+
+        let mut candidate_harness = Harness::default();
+        candidate_harness.process(r#"data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"config-get","args":{"action":"get"}}}]}}]}"#);
+        assert_eq!(candidate_harness.calls.finalized_tool_calls().len(), 1);
+    }
+
+    #[test]
+    fn top_level_status_updates_are_authoritative_terminals() {
+        let mut completed = Harness::default();
+        completed.process(
+            r#"data: {"event_type":"interaction.status_update","interaction_id":"inter_complete","status":"completed"}"#,
+        );
+        assert!(completed.finished);
+        assert_eq!(completed.status, "completed");
+        assert_eq!(completed.id, "inter_complete");
+        assert!(completed.failure.is_none());
+
+        let mut failed = Harness::default();
+        failed.process(r#"data: {"event_type":"step.start","index":0,"step":{"type":"function_call","id":"call_done","name":"system-ping","arguments":{}}}"#);
+        failed.process(r#"data: {"event_type":"step.stop","index":0}"#);
+        failed.process(r#"data: {"event_type":"step.delta","index":1,"delta":{"type":"arguments_delta","arguments":"{\"filePath\":\"partial"}}"#);
+        failed.process(r#"data: {"event_type":"interaction.status_update","status":"failed","message":"combined tools rejected api_key=status-secret"}"#);
+        assert!(failed.finished);
+        assert_eq!(failed.status, "failed");
+        assert!(!failed.calls.has_tool_state());
+        assert_eq!(
+            failed
+                .failure
+                .as_ref()
+                .map(InteractionsProviderFailure::reason),
+            Some(String::from("combined tools rejected api_key=[REDACTED]"))
+        );
+
+        let mut cancelled = Harness::default();
+        cancelled.process(r#"data: {"event_type":"step.start","index":0,"step":{"type":"function_call","id":"call_cancel","name":"system-ping","arguments":{}}}"#);
+        cancelled.process(r#"data: {"event_type":"step.stop","index":0}"#);
+        cancelled
+            .process(r#"data: {"event_type":"interaction.status_update","status":"cancelled"}"#);
+        assert!(cancelled.finished);
+        assert_eq!(cancelled.status, "cancelled");
+        assert!(!cancelled.calls.has_tool_state());
+        assert!(cancelled.failure.is_none());
+    }
+
+    #[test]
+    fn error_event_preserves_only_bounded_code_and_message() {
+        let mut harness = Harness::default();
+        let long_message = format!("provider failure\n{}", "x".repeat(1_000));
+        let event = json!({
+            "event_type": "error",
+            "error": {
+                "code": "INVALID_ARGUMENT",
+                "message": long_message,
+                "details": {"api_key": "must-not-be-surfaced"}
+            }
+        });
+        harness.process(&format!("data: {event}"));
+
+        assert!(harness.finished);
+        assert_eq!(harness.status, "failed");
+        assert!(!harness.calls.has_tool_state());
+        let reason = harness.failure.as_ref().unwrap().reason();
+        assert!(reason.starts_with("Interactions API error (INVALID_ARGUMENT): provider failure "));
+        assert!(reason.ends_with("..."));
+        assert!(!reason.contains('\n'));
+        assert!(!reason.contains("must-not-be-surfaced"));
+        assert!(reason.len() < 1_000);
+    }
+
+    #[test]
+    fn provider_failure_reason_redacts_message_secrets_and_structured_input() {
+        let mut harness = Harness::default();
+        let event = json!({
+            "event_type": "error",
+            "error": {
+                "code": "api_key=code-secret",
+                "message": "request rejected; authorization=auth-secret; prompt=\"private request\"; input=\"private input\"; Bearer bearer-secret",
+                "details": {
+                    "api_key": "details-secret",
+                    "prompt": "details prompt"
+                }
+            }
+        });
+        harness.process(&format!("data: {event}"));
+
+        let reason = harness.failure.as_ref().unwrap().reason();
+        for secret in [
+            "code-secret",
+            "auth-secret",
+            "private request",
+            "private input",
+            "bearer-secret",
+            "details-secret",
+            "details prompt",
+        ] {
+            assert!(!reason.contains(secret), "provider reason leaked {secret}");
+        }
+        assert!(reason.contains("[REDACTED]"));
+        assert!(!reason.contains("[REDACTED]]"));
+    }
+
+    #[test]
+    fn http_error_body_extracts_only_a_bounded_redacted_failure() {
+        let body = json!({
+            "error": {
+                "code": "INVALID_ARGUMENT",
+                "message": "invalid request api_key=body-secret",
+                "details": {
+                    "prompt": "private prompt",
+                    "input": "private input"
+                }
+            }
+        })
+        .to_string();
+
+        let reason = bounded_provider_error_response(&body);
+        assert_eq!(
+            reason,
+            "Interactions API error (INVALID_ARGUMENT): invalid request api_key=[REDACTED]"
+        );
+        assert!(!reason.contains("body-secret"));
+        assert!(!reason.contains("private prompt"));
+        assert!(!reason.contains("private input"));
+    }
+
+    #[test]
+    fn null_error_field_does_not_override_a_completed_terminal() {
+        let mut harness = Harness::default();
+        harness.process(
+            r#"data: {"event_type":"interaction.status_update","status":"completed","error":null}"#,
+        );
+
+        assert!(harness.finished);
+        assert_eq!(harness.status, "completed");
+        assert!(harness.failure.is_none());
+    }
+
+    #[test]
+    fn nested_terminal_status_and_error_event_name_alias_remain_supported() {
+        let mut nested = Harness::default();
+        nested.process(
+            r#"data: {"interaction":{"id":"inter_nested","status":"completed"},"steps":[]}"#,
+        );
+        assert!(nested.finished);
+        assert_eq!(nested.status, "completed");
+
+        let mut nested_failed = Harness::default();
+        nested_failed.process(r#"data: {"interaction":{"id":"inter_failed","status":"failed","error":{"code":"FAILED_PRECONDITION","message":"provider rejected token=nested-secret"}}}"#);
+        assert!(nested_failed.finished);
+        assert_eq!(nested_failed.status, "failed");
+        assert_eq!(
+            nested_failed
+                .failure
+                .as_ref()
+                .map(InteractionsProviderFailure::reason),
+            Some(String::from(
+                "Interactions API error (FAILED_PRECONDITION): provider rejected token=[REDACTED]"
+            ))
+        );
+
+        let mut error_alias = Harness::default();
+        error_alias.process(
+            r#"event: error
+data: {"code":503,"message":"provider unavailable"}"#,
+        );
+        assert!(error_alias.finished);
+        assert_eq!(error_alias.status, "failed");
+        assert_eq!(
+            error_alias
+                .failure
+                .as_ref()
+                .map(InteractionsProviderFailure::reason),
+            Some(String::from(
+                "Interactions API error (503): provider unavailable"
+            ))
+        );
+    }
+
+    #[test]
+    fn distinct_ids_preserve_repeated_calls_to_the_same_function() {
+        let mut harness = Harness::default();
+        harness.process(r#"data: {"tool_calls":[{"id":"call_first","name":"filesystem-read","arguments":{"filePath":"one.txt"}},{"id":"call_second","name":"filesystem-read","arguments":{"filePath":"two.txt"}}]}"#);
+
+        let calls = harness.calls.finalized_tool_calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0]["id"], "call_first");
+        assert_eq!(calls[0]["arguments"], json!({"filePath": "one.txt"}));
+        assert_eq!(calls[1]["id"], "call_second");
+        assert_eq!(calls[1]["arguments"], json!({"filePath": "two.txt"}));
+    }
+
+    #[test]
+    fn an_id_less_call_does_not_merge_with_a_provider_identified_call() {
+        let mut harness = Harness::default();
+        harness.process(r#"data: {"tool_calls":[{"id":"call_identified","name":"filesystem-read","arguments":{"filePath":"one.txt"}},{"name":"filesystem-read","arguments":{"filePath":"two.txt"}}]}"#);
+
+        let calls = harness.calls.finalized_tool_calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0]["id"], "call_identified");
+        assert_eq!(calls[0]["arguments"], json!({"filePath": "one.txt"}));
+        assert_eq!(calls[1]["arguments"], json!({"filePath": "two.txt"}));
+    }
+
+    #[test]
+    fn complete_steps_envelope_preserves_text_thinking_and_terminal_status() {
+        let mut harness = Harness::default();
+        harness.process(r#"data: {"id":"inter_direct","status":"completed","steps":[{"type":"thought","text":"plan"},{"type":"text","text":"answer"}]}"#);
+
+        assert!(harness.finished);
+        assert_eq!(harness.status, "completed");
+        assert_eq!(harness.thinking, ["plan"]);
+        assert_eq!(harness.content, ["answer"]);
+    }
+
+    #[test]
+    fn cancellation_and_attempt_reset_clear_all_tool_state() {
+        let mut state = InteractionsToolCallState::default();
+        state.register_step(
+            0,
+            &json!({
+                "type": "function_call",
+                "id": "call_done",
+                "name": "system-ping",
+                "arguments": {}
+            }),
+            true,
+        );
+        state.append_arguments(1, r#"{"filePath":"partial"#);
+        assert!(state.has_tool_state());
+        assert!(state.has_pending_tool_fragments());
+
+        state.clear();
+        assert!(!state.has_tool_state());
+        assert!(!state.has_pending_tool_fragments());
+        assert!(state.finalized_tool_calls().is_empty());
+    }
+}

--- a/native/src/api/interactions/mod.rs
+++ b/native/src/api/interactions/mod.rs
@@ -125,7 +125,10 @@ async fn create_interactions_response_async(
     )
     .await?;
 
-    let tools = if request.context_compaction.unwrap_or(false) || skip_context {
+    let tools = if request.context_compaction.unwrap_or(false)
+        || skip_context
+        || request.disable_tools.unwrap_or(false)
+    {
         None
     } else {
         match resolve_sub_agent_tools(&request).await {

--- a/native/src/api/interactions/mod.rs
+++ b/native/src/api/interactions/mod.rs
@@ -1,0 +1,284 @@
+//! Google Interactions API entry point.
+
+mod event;
+pub(crate) mod payload;
+mod stream;
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use napi::bindgen_prelude::*;
+use tokio_util::sync::CancellationToken;
+
+use crate::api::config::resolve_advanced_model;
+use crate::api::conversation::{
+    prepare_context_request, resolve_sub_agent_tools, ConversationContextRequest,
+};
+use crate::api::responses::{
+    ResponsesApiRequest, ResponsesApiResult, ResponsesApiStreamCallback, TokenUsage,
+};
+use crate::api::retry::{
+    classify_final_stream_warning, resolve_stream_idle_timeout_sec, FinalStreamWarningDisposition,
+    RetryOptions,
+};
+use crate::storage::services::app_logs::{log_api_error, log_api_warning, maybe_log_api_request};
+use crate::storage::services::chat_conversations::{
+    store_chat_exchange, ChatContextMessage, StoreChatExchangeInput,
+};
+use crate::storage::ApiConfigRecord;
+
+/// Public entry point — create a Google Interactions streaming response.
+pub async fn create_interactions_response_stream(
+    request: ResponsesApiRequest,
+    database_path: PathBuf,
+    api_config: ApiConfigRecord,
+    custom_headers: HashMap<String, String>,
+    on_chunk: ResponsesApiStreamCallback,
+    cancel_token: CancellationToken,
+) -> Result<ResponsesApiResult> {
+    create_interactions_response_async(
+        request,
+        database_path,
+        api_config,
+        custom_headers,
+        &on_chunk,
+        cancel_token,
+    )
+    .await
+}
+
+async fn create_interactions_response_async(
+    request: ResponsesApiRequest,
+    database_path: PathBuf,
+    api_config: ApiConfigRecord,
+    custom_headers: HashMap<String, String>,
+    on_chunk: &ResponsesApiStreamCallback,
+    cancel_token: CancellationToken,
+) -> Result<ResponsesApiResult> {
+    if request.messages.is_empty() {
+        return Err(Error::from_reason("At least one chat message is required"));
+    }
+
+    let api_key = api_config.api_key.trim();
+    if api_key.is_empty() {
+        return Err(Error::from_reason(
+            "API key not configured. Please configure API settings first.",
+        ));
+    }
+
+    let model = resolve_advanced_model(request.model.as_deref(), &api_config.advanced_model)?;
+
+    let endpoint = payload::resolve_interactions_endpoint(&api_config, api_key);
+    if endpoint.is_empty() {
+        return Err(Error::from_reason(
+            "Base URL not configured. Please configure API settings first.",
+        ));
+    }
+
+    let request_messages = request
+        .messages
+        .iter()
+        .map(|message| ChatContextMessage {
+            role: message.role.clone(),
+            content: message.content.clone(),
+            tool_calls_json: None,
+            tool_results_json: message.tool_results_json.clone(),
+            thinking: message.thinking.clone(),
+            thinking_blocks_json: message.thinking_blocks_json.clone(),
+        })
+        .collect::<Vec<_>>();
+
+    let prepared_request = prepare_context_request(ConversationContextRequest {
+        database_path: &database_path,
+        conversation_id: request.conversation_id.as_deref(),
+        previous_response_id: request.previous_response_id.as_deref(),
+        messages: &request_messages,
+        max_context_tokens: api_config.max_context_tokens,
+        directory_id: request.directory_id.as_deref(),
+        context_compaction: request.context_compaction.unwrap_or(false),
+        resume_after_compaction: request.resume_after_compaction.unwrap_or(false),
+        skip_context: request.skip_context.unwrap_or(false),
+        plan_mode: request.plan_mode.unwrap_or(false),
+        goal_mode: request.goal_mode.unwrap_or(false),
+        worktree_mode: request.worktree_mode.unwrap_or(false),
+        is_sub_agent: request.is_sub_agent_request(),
+        sub_agent_system_prompt: request.sub_agent_system_prompt.as_deref(),
+        system_prompt_ids_json: &api_config.system_prompt_ids_json,
+        remote_role_content: request.remote_role_content.as_deref(),
+        remote_include_global_rules: request.remote_include_global_rules,
+    })
+    .await?;
+
+    let client = crate::api::http_client::build_proxied_client()
+        .await
+        .map_err(|error| Error::from_reason(format!("Failed to create HTTP client: {}", error)))?;
+    let skip_context = request.skip_context.unwrap_or(false);
+    let mut prepared_messages = prepared_request.messages;
+    crate::api::vision::textify_images_in_messages(
+        &mut prepared_messages,
+        &database_path,
+        &api_config,
+        &custom_headers,
+        skip_context,
+        Some(on_chunk),
+        Some(&cancel_token),
+    )
+    .await?;
+
+    let tools = if request.context_compaction.unwrap_or(false) || skip_context {
+        None
+    } else {
+        match resolve_sub_agent_tools(&request).await {
+            Ok(tools) => Some(crate::mcp::tools::tools_as_interactions_json(&tools)),
+            Err(error) => {
+                eprintln!("Failed to prepare MCP tools for Interactions API: {error}");
+                None
+            }
+        }
+    };
+
+    let payload = payload::build_interactions_payload(
+        &prepared_messages,
+        &database_path,
+        &request,
+        &api_config,
+        tools,
+        &prepared_request.user_system_prompts,
+    )?;
+
+    let retry_options = RetryOptions::from_config(
+        api_config.max_retries,
+        api_config.retry_base_delay_ms,
+        api_config.partial_retry_max_chars,
+    );
+    let stream_idle_timeout_sec =
+        resolve_stream_idle_timeout_sec(api_config.stream_idle_timeout_sec);
+    let request_payload_json = serde_json::to_string(&payload).unwrap_or_default();
+    maybe_log_api_request(
+        database_path.clone(),
+        "interactions".to_string(),
+        endpoint.clone(),
+        request_payload_json,
+    )
+    .await;
+
+    let streamed_response = match stream::collect_interactions_stream(
+        &client,
+        &endpoint,
+        &custom_headers,
+        payload,
+        on_chunk,
+        &cancel_token,
+        &retry_options,
+        stream_idle_timeout_sec,
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(error) => {
+            log_api_error(
+                &database_path,
+                "create_interactions_response_stream",
+                "Google Interactions API call failed",
+                &error.reason,
+            );
+            return Err(error);
+        }
+    };
+
+    let raw_response_json = "{}";
+    let interruption_reason = streamed_response
+        .interruption_reason
+        .map(|reason| reason.as_code().to_string());
+    let recovery_outcome = streamed_response
+        .recovery_outcome
+        .map(|outcome| outcome.as_code().to_string());
+
+    let has_response_payload = !streamed_response.content.is_empty()
+        || !streamed_response.thinking.is_empty()
+        || streamed_response.tool_calls_json != "[]";
+    match classify_final_stream_warning(
+        &streamed_response.status,
+        streamed_response.interruption_reason,
+        has_response_payload,
+    ) {
+        FinalStreamWarningDisposition::TransportInterrupted(reason) => {
+            log_api_warning(
+                &database_path,
+                "create_interactions_response_stream",
+                "AI response stream interrupted",
+                &format!(
+                    "provider=interactions, request_method=interactions, reason={}, outcome={}, model={}, status={}, conversation_id={}, response_id={}, content_chars={}, thinking_chars={}, duration_ms={}",
+                    reason.as_code(),
+                    recovery_outcome.as_deref().unwrap_or(""),
+                    model,
+                    streamed_response.status,
+                    prepared_request.conversation_id,
+                    streamed_response.id,
+                    streamed_response.content.chars().count(),
+                    streamed_response.thinking.chars().count(),
+                    streamed_response.total_duration_ms,
+                ),
+            );
+        }
+        FinalStreamWarningDisposition::EmptyResponse => {
+            log_api_warning(
+                &database_path,
+                "create_interactions_response_stream",
+                "AI returned empty response",
+                &format!(
+                    "model={}, status={}",
+                    streamed_response.model, streamed_response.status
+                ),
+            );
+        }
+        FinalStreamWarningDisposition::None => {}
+    }
+
+    let persisted_user_message_ids = if !skip_context {
+        store_chat_exchange(
+            &database_path,
+            &StoreChatExchangeInput {
+                conversation_id: &prepared_request.conversation_id,
+                request_messages: &prepared_request.current_messages,
+                response_content: &streamed_response.content,
+                response_id: &streamed_response.id,
+                checkpoint_id: request.checkpoint_id.as_deref().unwrap_or(""),
+                model: &model,
+                api_profile_name: &api_config.profile_name,
+                status: &streamed_response.status,
+                interruption_reason: interruption_reason.as_deref(),
+                recovery_outcome: recovery_outcome.as_deref(),
+                raw_response_json: &raw_response_json,
+                token_usage: streamed_response.token_usage,
+                response_thinking: &streamed_response.thinking,
+                response_thinking_blocks_json: "[]",
+                tool_calls_json: &streamed_response.tool_calls_json,
+                directory_id: request.directory_id.as_deref().unwrap_or(""),
+                context_compaction: request.context_compaction.unwrap_or(false),
+                total_duration_ms: streamed_response.total_duration_ms,
+            },
+        )?
+    } else {
+        Vec::new()
+    };
+
+    Ok(ResponsesApiResult {
+        id: streamed_response.id,
+        conversation_id: prepared_request.conversation_id,
+        content: streamed_response.content,
+        thinking: streamed_response.thinking,
+        model: model.to_string(),
+        status: streamed_response.status,
+        interruption_reason,
+        recovery_outcome,
+        tool_calls_json: streamed_response.tool_calls_json,
+        token_usage: TokenUsage {
+            input_tokens: streamed_response.token_usage.input_tokens,
+            output_tokens: streamed_response.token_usage.output_tokens,
+            cache_creation_input_tokens: streamed_response.token_usage.cache_creation_input_tokens,
+            cache_read_input_tokens: streamed_response.token_usage.cache_read_input_tokens,
+        },
+        persisted_user_message_ids,
+    })
+}

--- a/native/src/api/interactions/payload.rs
+++ b/native/src/api/interactions/payload.rs
@@ -12,7 +12,7 @@ use crate::api::conversation::tool_messages::{
     normalize_tool_calls, parse_tool_results_with_images,
 };
 use crate::api::gemini::payload::{
-    build_gemini_google_search_enabled, build_gemini_thinking_config,
+    build_gemini_thinking_config, should_include_gemini_google_search,
 };
 use crate::api::responses::ResponsesApiRequest;
 use crate::storage::services::chat_conversations::ChatContextMessage;
@@ -173,30 +173,36 @@ pub(super) fn build_interactions_payload(
         }
     }
 
-    let google_search_enabled = build_gemini_google_search_enabled(&api_config.config_json);
-    if google_search_enabled {
-        if let Some(first_tool) = tool_entries.first_mut().and_then(Value::as_object_mut) {
-            first_tool.insert("google_search".to_string(), json!({}));
-        } else {
-            tool_entries.push(json!({ "google_search": {} }));
-        }
+    // A duplicate-read recovery deliberately has no provider tools at all.
+    // Google Search is a provider tool too, even though it is configured
+    // independently from MCP function declarations.
+    let google_search_enabled = should_include_gemini_google_search(
+        &api_config.config_json,
+        request.disable_tools.unwrap_or(false),
+    );
+    let is_cli_proxy_api = api_config
+        .base_url
+        .to_ascii_lowercase()
+        .contains("cliproxyapi");
+    let has_function_tools = tool_entries.iter().any(|entry| {
+        entry
+            .get("function_declarations")
+            .and_then(Value::as_array)
+            .is_some_and(|declarations| !declarations.is_empty())
+    });
+    let include_google_search = google_search_enabled && !(is_cli_proxy_api && has_function_tools);
+    if include_google_search {
+        // Keep server-side and function tools as separate Tool objects. CPA
+        // rejects a single object that mixes google_search with function
+        // declarations even when tool_config is present.
+        tool_entries.push(json!({ "google_search": {} }));
     }
-
-    let has_combined_server_side_tools = google_search_enabled
-        && tool_entries.iter().any(|entry| {
-            entry.as_object().is_some_and(|tool| {
-                tool.get("function_declarations")
-                    .and_then(Value::as_array)
-                    .is_some_and(|declarations| !declarations.is_empty())
-                    && tool.contains_key("google_search")
-            })
-        });
 
     if !tool_entries.is_empty() {
         payload["tools"] = Value::Array(tool_entries);
     }
 
-    if has_combined_server_side_tools {
+    if (include_google_search && has_function_tools) || (is_cli_proxy_api && has_function_tools) {
         payload["tool_config"] = json!({
             "include_server_side_tool_invocations": true
         });
@@ -206,9 +212,18 @@ pub(super) fn build_interactions_payload(
     }
 
     // System instruction
-    if !user_system_prompts.is_empty() {
+    let mut system_instruction_parts = user_system_prompts.to_vec();
+    if let Some(prompt) = request
+        .internal_recovery_prompt
+        .as_deref()
+        .map(str::trim)
+        .filter(|prompt| !prompt.is_empty())
+    {
+        system_instruction_parts.push(prompt.to_string());
+    }
+    if !system_instruction_parts.is_empty() {
         payload["system_instruction"] = json!({
-            "parts": [{ "text": user_system_prompts.join("\n\n") }]
+            "parts": [{ "text": system_instruction_parts.join("\n\n") }]
         });
     }
 
@@ -385,6 +400,8 @@ mod tests {
             sub_agent_system_prompt: None,
             sub_agent_config_profile: None,
             skip_context: None,
+            disable_tools: None,
+            internal_recovery_prompt: None,
             plan_mode: None,
             goal_mode: None,
             worktree_mode: None,
@@ -502,6 +519,7 @@ mod tests {
             payload["generation_config"]["thinking_config"],
             json!({
                 "thinkingLevel": "high",
+                "includeThoughts": true,
                 "thinking_level": "high"
             })
         );
@@ -520,6 +538,32 @@ mod tests {
         .expect("Interactions payload");
 
         assert!(payload.get("generation_config").is_none());
+    }
+
+    #[test]
+    fn internal_recovery_prompt_is_an_interactions_system_instruction() {
+        let mut request = create_test_request();
+        request.internal_recovery_prompt =
+            Some("Use completed results and answer without tools.".to_string());
+        let payload = build_interactions_payload(
+            &[create_test_message()],
+            Path::new("."),
+            &request,
+            &create_test_record(""),
+            None,
+            &["configured system rule".to_string()],
+        )
+        .expect("Interactions payload");
+
+        assert_eq!(
+            payload["system_instruction"],
+            json!({"parts": [{"text": "configured system rule\n\nUse completed results and answer without tools."}]})
+        );
+        assert!(payload["input"]
+            .as_array()
+            .expect("input array")
+            .iter()
+            .all(|entry| entry["text"] != "Use completed results and answer without tools."));
     }
 
     #[test]
@@ -574,7 +618,7 @@ mod tests {
             .as_array()
             .expect("function declarations");
 
-        assert_eq!(tool_entries.len(), 1);
+        assert_eq!(tool_entries.len(), 2);
         assert!(tool_entries[0].get("type").is_none());
         assert_eq!(declarations.len(), 2);
         assert_eq!(declarations[0]["name"], "todo-todo-manage");
@@ -592,8 +636,8 @@ mod tests {
             declarations[1]["parameters"]["properties"]["filePath"]["type"],
             "string"
         );
-        assert_eq!(tool_entries[0]["google_search"], json!({}));
-        assert!(tool_entries[0].get("functionDeclarations").is_none());
+        assert_eq!(tool_entries[1]["google_search"], json!({}));
+        assert!(tool_entries[1].get("function_declarations").is_none());
         assert_eq!(
             payload["tool_config"],
             json!({ "include_server_side_tool_invocations": true })

--- a/native/src/api/interactions/payload.rs
+++ b/native/src/api/interactions/payload.rs
@@ -1,0 +1,1081 @@
+//! Google Interactions API payload construction and endpoint resolution.
+
+use std::collections::{HashMap, VecDeque};
+use std::path::Path;
+
+use napi::bindgen_prelude::*;
+use serde_json::{json, Value};
+
+use crate::api::config::{normalize_base_url, resolve_sdk_api_base_url, DEFAULT_OPENAI_BASE_URL};
+use crate::api::conversation::parse_chat_message_content;
+use crate::api::conversation::tool_messages::{
+    normalize_tool_calls, parse_tool_results_with_images,
+};
+use crate::api::gemini::payload::{
+    build_gemini_google_search_enabled, build_gemini_thinking_config,
+};
+use crate::api::responses::ResponsesApiRequest;
+use crate::storage::services::chat_conversations::ChatContextMessage;
+use crate::storage::ApiConfigRecord;
+
+pub const DEFAULT_INTERACTIONS_BASE_URL: &str = "https://generativelanguage.googleapis.com";
+
+pub(crate) fn resolve_interactions_endpoint(api_config: &ApiConfigRecord, api_key: &str) -> String {
+    let normalized_base_url = normalize_base_url(&api_config.base_url);
+    let base_url =
+        if normalized_base_url.is_empty() || normalized_base_url == DEFAULT_OPENAI_BASE_URL {
+            DEFAULT_INTERACTIONS_BASE_URL.to_string()
+        } else {
+            normalized_base_url
+        };
+
+    let resolved_base = if api_config.base_url_mode == "endpoint" {
+        base_url
+    } else {
+        resolve_sdk_api_base_url(&base_url, &api_config.base_url_mode)
+    };
+
+    let base_trimmed = resolved_base.trim_end_matches('/');
+    let mut url = if base_trimmed.ends_with("/interactions") {
+        format!("{base_trimmed}?alt=sse")
+    } else if base_trimmed.ends_with("/v1beta") || base_trimmed.ends_with("/v1") {
+        format!("{base_trimmed}/interactions?alt=sse")
+    } else {
+        format!("{base_trimmed}/v1beta/interactions?alt=sse")
+    };
+
+    if !api_key.is_empty() && !url.contains("&key=") && !url.contains("?key=") {
+        url.push_str(&format!("&key={}", api_key));
+    }
+
+    url
+}
+
+pub(super) fn build_interactions_payload(
+    messages: &[ChatContextMessage],
+    database_path: &Path,
+    request: &ResponsesApiRequest,
+    api_config: &ApiConfigRecord,
+    tools: Option<Value>,
+    user_system_prompts: &[String],
+) -> Result<Value> {
+    let clean_model = request
+        .model
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(api_config.advanced_model.as_str())
+        .strip_prefix("models/")
+        .unwrap_or(&api_config.advanced_model);
+
+    // The proxy may route this request through ordinary Gemini, so replay
+    // complete call/result pairs instead of relying only on interaction state.
+    let mut input_parts = Vec::new();
+    let paired_tools = pair_interactions_tool_history(messages, database_path, request);
+
+    for (message_index, message) in messages.iter().enumerate() {
+        let content = message.content.trim();
+        let role = message.role.trim();
+
+        if role == "tool" {
+            continue;
+        }
+
+        if content.is_empty() && !paired_tools.pairs.contains_key(&message_index) {
+            continue;
+        }
+
+        if !content.is_empty() {
+            let parsed_content = parse_chat_message_content(content, database_path)?;
+            if !parsed_content.text.is_empty() {
+                input_parts.push(json!({
+                    "type": "text",
+                    "text": parsed_content.text,
+                    "role": role,
+                }));
+            }
+            for image in &parsed_content.images {
+                input_parts.push(json!({
+                    "type": "image",
+                    "inline_data": {
+                        "mime_type": image.media_type,
+                        "data": image.data,
+                    }
+                }));
+            }
+        }
+
+        if let Some(pairs) = paired_tools.pairs.get(&message_index) {
+            for pair in pairs {
+                let call = &pair.call;
+                input_parts.push(json!({
+                    "type": "function_call",
+                    "id": call.id,
+                    "name": call.name,
+                    "arguments": call.arguments,
+                }));
+                let result = &pair.result;
+                let result_text = if result.text.is_empty() {
+                    if result.images.is_empty() {
+                        "ok"
+                    } else {
+                        "[image attached]"
+                    }
+                } else {
+                    result.text.as_str()
+                };
+                input_parts.push(json!({
+                    "type": "function_result",
+                    "call_id": result.call_id,
+                    "name": result.name,
+                    "result": { "result": result_text },
+                }));
+                for image in &result.images {
+                    input_parts.push(json!({
+                        "type": "image",
+                        "inline_data": {
+                            "mime_type": image.media_type,
+                            "data": image.data,
+                        }
+                    }));
+                }
+            }
+        }
+    }
+
+    if input_parts.is_empty() {
+        return Err(Error::from_reason("Chat message content is required"));
+    }
+
+    let mut payload = json!({
+        "model": clean_model,
+        "stream": true,
+        "input": input_parts,
+    });
+
+    // Previous interaction ID (for stateful continuity)
+    if !paired_tools.has_pairs() {
+        if let Some(prev_id) = request
+            .previous_response_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+        {
+            payload["previous_interaction_id"] = json!(prev_id);
+        }
+    }
+
+    // The configured proxy accepts a single snake_case Gemini Tool object.
+    let mut tool_entries = Vec::new();
+    if let Some(tools_val) = tools {
+        if let Some(arr) = tools_val.as_array() {
+            tool_entries.extend(arr.iter().cloned());
+        }
+    }
+
+    let google_search_enabled = build_gemini_google_search_enabled(&api_config.config_json);
+    if google_search_enabled {
+        if let Some(first_tool) = tool_entries.first_mut().and_then(Value::as_object_mut) {
+            first_tool.insert("google_search".to_string(), json!({}));
+        } else {
+            tool_entries.push(json!({ "google_search": {} }));
+        }
+    }
+
+    let has_combined_server_side_tools = google_search_enabled
+        && tool_entries.iter().any(|entry| {
+            entry.as_object().is_some_and(|tool| {
+                tool.get("function_declarations")
+                    .and_then(Value::as_array)
+                    .is_some_and(|declarations| !declarations.is_empty())
+                    && tool.contains_key("google_search")
+            })
+        });
+
+    if !tool_entries.is_empty() {
+        payload["tools"] = Value::Array(tool_entries);
+    }
+
+    if has_combined_server_side_tools {
+        payload["tool_config"] = json!({
+            "include_server_side_tool_invocations": true
+        });
+        payload["toolConfig"] = json!({
+            "includeServerSideToolInvocations": true
+        });
+    }
+
+    // System instruction
+    if !user_system_prompts.is_empty() {
+        payload["system_instruction"] = json!({
+            "parts": [{ "text": user_system_prompts.join("\n\n") }]
+        });
+    }
+
+    // Generation configuration (thinking, max output tokens, etc.)
+    let mut generation_config = json!({});
+    if let Some(mut thinking_config) = build_gemini_thinking_config(&api_config.config_json) {
+        if let Some(level) = thinking_config
+            .get("thinkingLevel")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+        {
+            thinking_config["thinking_level"] = json!(level.clone());
+            generation_config["thinking_level"] = json!(level);
+        }
+        generation_config["thinking_summaries"] = json!("auto");
+        generation_config["thinking_config"] = thinking_config;
+    }
+    if let Some(max_tokens) = api_config.max_tokens {
+        if max_tokens > 0 {
+            generation_config["max_output_tokens"] = json!(max_tokens);
+        }
+    }
+
+    if generation_config
+        .as_object()
+        .map_or(false, |o| !o.is_empty())
+    {
+        payload["generation_config"] = generation_config;
+    }
+
+    Ok(payload)
+}
+
+#[derive(Default)]
+struct PairedToolHistory {
+    pairs: HashMap<usize, Vec<PairedFunctionExchange>>,
+}
+
+impl PairedToolHistory {
+    fn has_pairs(&self) -> bool {
+        !self.pairs.is_empty()
+    }
+}
+
+struct PairedFunctionExchange {
+    call: PairedFunctionCall,
+    result: PairedFunctionResult,
+}
+
+struct PairedFunctionCall {
+    id: String,
+    name: String,
+    arguments: Value,
+}
+
+struct PairedFunctionResult {
+    call_id: String,
+    name: String,
+    text: String,
+    images: Vec<crate::api::conversation::ChatImage>,
+}
+
+fn pair_interactions_tool_history(
+    messages: &[ChatContextMessage],
+    database_path: &Path,
+    request: &ResponsesApiRequest,
+) -> PairedToolHistory {
+    let mut pending: HashMap<(String, String), VecDeque<(usize, usize)>> = HashMap::new();
+    let mut calls_by_message = HashMap::new();
+    let mut matched_results: HashMap<(usize, usize), PairedFunctionResult> = HashMap::new();
+
+    for (message_index, message) in messages.iter().enumerate() {
+        match message.role.trim() {
+            "assistant" => {
+                // A new model turn cannot complete calls left unresolved by an
+                // earlier model turn.
+                pending.clear();
+                let calls = message
+                    .tool_calls_json
+                    .as_deref()
+                    .map(normalize_tool_calls)
+                    .unwrap_or_default();
+                for (call_index, call) in calls.iter().enumerate() {
+                    if !call.has_valid_name || !call.has_valid_input {
+                        continue;
+                    }
+                    pending
+                        .entry((call.id.clone(), call.name.clone()))
+                        .or_default()
+                        .push_back((message_index, call_index));
+                }
+                calls_by_message.insert(message_index, calls);
+            }
+            "tool" => {
+                let results = message
+                    .tool_results_json
+                    .as_deref()
+                    .map(|raw| {
+                        parse_tool_results_with_images(
+                            raw,
+                            database_path,
+                            request.skip_context.unwrap_or(false),
+                        )
+                    })
+                    .unwrap_or_default();
+                for result in results {
+                    if !result.has_valid_shape {
+                        continue;
+                    }
+                    let key = (result.call_id.clone(), result.name.clone());
+                    if key.0.trim().is_empty() || key.1.trim().is_empty() {
+                        continue;
+                    }
+                    let Some(call_position) = pending.get_mut(&key).and_then(VecDeque::pop_front)
+                    else {
+                        continue;
+                    };
+                    matched_results.insert(
+                        call_position,
+                        PairedFunctionResult {
+                            call_id: result.call_id,
+                            name: result.name,
+                            text: result.text,
+                            images: result.images,
+                        },
+                    );
+                }
+            }
+            _ => pending.clear(),
+        }
+    }
+
+    let pairs = calls_by_message
+        .into_iter()
+        .filter_map(|(message_index, calls)| {
+            let matched = calls
+                .into_iter()
+                .enumerate()
+                .filter_map(|(call_index, call)| {
+                    let result = matched_results.remove(&(message_index, call_index))?;
+                    Some(PairedFunctionExchange {
+                        call: PairedFunctionCall {
+                            id: call.id,
+                            name: call.name,
+                            arguments: call.input,
+                        },
+                        result,
+                    })
+                })
+                .collect::<Vec<_>>();
+            (!matched.is_empty()).then_some((message_index, matched))
+        })
+        .collect();
+
+    PairedToolHistory { pairs }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_request() -> ResponsesApiRequest {
+        ResponsesApiRequest {
+            messages: Vec::new(),
+            model: Some("gemini-3.7-flash".to_string()),
+            api_profile: None,
+            conversation_id: None,
+            previous_response_id: None,
+            directory_id: None,
+            checkpoint_id: None,
+            context_compaction: None,
+            resume_after_compaction: None,
+            sub_agent_tools_json: None,
+            sub_agent_system_prompt: None,
+            sub_agent_config_profile: None,
+            skip_context: None,
+            plan_mode: None,
+            goal_mode: None,
+            worktree_mode: None,
+            thinking_strength: None,
+            responses_fast_mode: None,
+            remote_role_content: None,
+            remote_include_global_rules: None,
+        }
+    }
+
+    fn create_test_message() -> ChatContextMessage {
+        ChatContextMessage {
+            role: "user".to_string(),
+            content: "Read package.json".to_string(),
+            tool_calls_json: None,
+            tool_results_json: None,
+            thinking: None,
+            thinking_blocks_json: None,
+        }
+    }
+
+    fn message(
+        role: &str,
+        content: &str,
+        tool_calls_json: Option<Value>,
+        tool_results_json: Option<Value>,
+    ) -> ChatContextMessage {
+        ChatContextMessage {
+            role: role.to_string(),
+            content: content.to_string(),
+            tool_calls_json: tool_calls_json.map(|value| value.to_string()),
+            tool_results_json: tool_results_json.map(|value| value.to_string()),
+            thinking: None,
+            thinking_blocks_json: None,
+        }
+    }
+
+    fn create_test_record(base_url: &str) -> ApiConfigRecord {
+        ApiConfigRecord {
+            id: "1".to_string(),
+            profile_name: "default".to_string(),
+            display_name: "Default".to_string(),
+            is_active: true,
+            base_url: base_url.to_string(),
+            base_url_mode: "default".to_string(),
+            api_key: "test-key".to_string(),
+            request_method: "interactions".to_string(),
+            advanced_model: "gemini-3.7-flash".to_string(),
+            basic_model: "gemini-3.7-flash".to_string(),
+            supports_vision: true,
+            vision_base_url: "".to_string(),
+            vision_base_url_mode: "default".to_string(),
+            vision_api_key: "".to_string(),
+            vision_request_method: "interactions".to_string(),
+            vision_model: "".to_string(),
+            max_context_tokens: None,
+            max_tokens: None,
+            stream_idle_timeout_sec: None,
+            enable_auto_compress: false,
+            auto_compress_threshold: None,
+            max_retries: None,
+            retry_base_delay_ms: None,
+            partial_retry_max_chars: None,
+            system_prompt_ids_json: "[]".to_string(),
+            custom_header_scheme_id: "".to_string(),
+            config_json: "{}".to_string(),
+            source: "manual".to_string(),
+            updated_at: "".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_resolve_interactions_endpoint() {
+        let config = create_test_record("");
+        let ep = resolve_interactions_endpoint(&config, "test-key");
+        assert_eq!(
+            ep,
+            "https://generativelanguage.googleapis.com/v1beta/interactions?alt=sse&key=test-key"
+        );
+
+        let config2 = create_test_record("http://localhost:8317/v1beta");
+        let ep2 = resolve_interactions_endpoint(&config2, "local-key");
+        assert_eq!(
+            ep2,
+            "http://localhost:8317/v1beta/interactions?alt=sse&key=local-key"
+        );
+    }
+
+    #[test]
+    fn requests_interactions_thinking_summaries_when_thinking_is_enabled() {
+        let mut config = create_test_record("");
+        config.config_json = json!({
+            "snowcfg": {
+                "geminiThinking": {
+                    "enabled": true,
+                    "thinkingLevel": "high"
+                }
+            }
+        })
+        .to_string();
+
+        let payload = build_interactions_payload(
+            &[create_test_message()],
+            Path::new("."),
+            &create_test_request(),
+            &config,
+            None,
+            &[],
+        )
+        .expect("Interactions payload");
+
+        assert_eq!(payload["generation_config"]["thinking_level"], "high");
+        assert_eq!(payload["generation_config"]["thinking_summaries"], "auto");
+        assert_eq!(
+            payload["generation_config"]["thinking_config"],
+            json!({
+                "thinkingLevel": "high",
+                "thinking_level": "high"
+            })
+        );
+    }
+
+    #[test]
+    fn omits_interactions_thinking_fields_when_thinking_is_disabled() {
+        let payload = build_interactions_payload(
+            &[create_test_message()],
+            Path::new("."),
+            &create_test_request(),
+            &create_test_record(""),
+            None,
+            &[],
+        )
+        .expect("Interactions payload");
+
+        assert!(payload.get("generation_config").is_none());
+    }
+
+    #[test]
+    fn builds_one_grouped_function_and_google_search_tool_object() {
+        let mut config = create_test_record("");
+        config.config_json = json!({
+            "snowcfg": {
+                "googleSearch": true
+            }
+        })
+        .to_string();
+        let tools = json!([
+            {
+                "function_declarations": [
+                    {
+                        "name": "todo-todo-manage",
+                        "description": "Manage todos",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "action": { "type": "string" }
+                            },
+                            "required": ["action"]
+                        }
+                    },
+                    {
+                        "name": "filesystem-read",
+                        "description": "Read a file",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "filePath": { "type": "string" }
+                            },
+                            "required": ["filePath"]
+                        }
+                    },
+                ]
+            }
+        ]);
+
+        let payload = build_interactions_payload(
+            &[create_test_message()],
+            Path::new("."),
+            &create_test_request(),
+            &config,
+            Some(tools),
+            &[],
+        )
+        .expect("Interactions payload");
+        let tool_entries = payload["tools"].as_array().expect("tools array");
+        let declarations = tool_entries[0]["function_declarations"]
+            .as_array()
+            .expect("function declarations");
+
+        assert_eq!(tool_entries.len(), 1);
+        assert!(tool_entries[0].get("type").is_none());
+        assert_eq!(declarations.len(), 2);
+        assert_eq!(declarations[0]["name"], "todo-todo-manage");
+        assert_eq!(declarations[0]["parameters"]["required"], json!(["action"]));
+        assert_eq!(
+            declarations[0]["parameters"]["properties"]["action"]["type"],
+            "string"
+        );
+        assert_eq!(declarations[1]["name"], "filesystem-read");
+        assert_eq!(
+            declarations[1]["parameters"]["required"],
+            json!(["filePath"])
+        );
+        assert_eq!(
+            declarations[1]["parameters"]["properties"]["filePath"]["type"],
+            "string"
+        );
+        assert_eq!(tool_entries[0]["google_search"], json!({}));
+        assert!(tool_entries[0].get("functionDeclarations").is_none());
+        assert_eq!(
+            payload["tool_config"],
+            json!({ "include_server_side_tool_invocations": true })
+        );
+        assert_eq!(
+            payload["toolConfig"],
+            json!({ "includeServerSideToolInvocations": true })
+        );
+    }
+
+    #[test]
+    fn builds_google_search_only_without_a_type_discriminator() {
+        let mut config = create_test_record("");
+        config.config_json = json!({
+            "snowcfg": {
+                "googleSearch": true
+            }
+        })
+        .to_string();
+
+        let payload = build_interactions_payload(
+            &[create_test_message()],
+            Path::new("."),
+            &create_test_request(),
+            &config,
+            None,
+            &[],
+        )
+        .expect("Interactions payload");
+
+        assert_eq!(payload["tools"], json!([{ "google_search": {} }]));
+        assert!(payload["tools"][0].get("type").is_none());
+        assert!(payload.get("tool_config").is_none());
+        assert!(payload.get("toolConfig").is_none());
+    }
+
+    #[test]
+    fn does_not_add_google_search_when_it_is_disabled() {
+        let config = create_test_record("");
+        let tools = json!([{
+            "function_declarations": [{
+                "name": "filesystem-read",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "filePath": { "type": "string" }
+                    },
+                    "required": ["filePath"]
+                }
+            }]
+        }]);
+
+        let payload = build_interactions_payload(
+            &[create_test_message()],
+            Path::new("."),
+            &create_test_request(),
+            &config,
+            Some(tools.clone()),
+            &[],
+        )
+        .expect("Interactions payload");
+
+        assert_eq!(payload["tools"], tools);
+        assert!(payload["tools"][0].get("google_search").is_none());
+        assert!(payload["tools"][0].get("type").is_none());
+        assert!(payload.get("tool_config").is_none());
+        assert!(payload.get("toolConfig").is_none());
+    }
+
+    #[test]
+    fn does_not_enable_server_side_invocations_for_empty_or_malformed_tools() {
+        let mut config = create_test_record("");
+        config.config_json = json!({
+            "snowcfg": {
+                "googleSearch": true
+            }
+        })
+        .to_string();
+
+        let cases = [
+            None,
+            Some(json!([])),
+            Some(json!({
+                "function_declarations": [{ "name": "ignored-non-array" }]
+            })),
+            Some(json!([{ "function_declarations": [] }])),
+            Some(json!([null])),
+        ];
+
+        for tools in cases {
+            let payload = build_interactions_payload(
+                &[create_test_message()],
+                Path::new("."),
+                &create_test_request(),
+                &config,
+                tools,
+                &[],
+            )
+            .expect("Interactions payload");
+
+            assert!(payload.get("tools").is_some());
+            assert!(payload.get("tool_config").is_none());
+            assert!(payload.get("toolConfig").is_none());
+        }
+    }
+
+    #[test]
+    fn replays_ordered_id_and_name_matched_function_pairs() {
+        let messages = vec![
+            message("user", "Inspect the project", None, None),
+            message(
+                "assistant",
+                "",
+                Some(json!([
+                    {
+                        "type": "function_call",
+                        "id": "call-1",
+                        "name": "filesystem-read",
+                        "arguments": { "filePath": "package.json" }
+                    },
+                    {
+                        "type": "function_call",
+                        "id": "call-2",
+                        "name": "filesystem-read",
+                        "arguments": { "filePath": "native/Cargo.toml" }
+                    }
+                ])),
+                None,
+            ),
+            message(
+                "tool",
+                "",
+                None,
+                Some(json!([
+                    {
+                        "name": "filesystem-read",
+                        "callId": "call-1",
+                        "result": "package result"
+                    },
+                    {
+                        "name": "filesystem-read",
+                        "callId": "call-2",
+                        "result": "cargo result"
+                    }
+                ])),
+            ),
+            message("user", "Continue", None, None),
+        ];
+        let payload = build_interactions_payload(
+            &messages,
+            Path::new("."),
+            &create_test_request(),
+            &create_test_record(""),
+            None,
+            &[],
+        )
+        .expect("Interactions payload");
+        let input = payload["input"].as_array().expect("input array");
+
+        assert_eq!(
+            input
+                .iter()
+                .map(|step| step["type"].as_str().unwrap())
+                .collect::<Vec<_>>(),
+            vec![
+                "text",
+                "function_call",
+                "function_result",
+                "function_call",
+                "function_result",
+                "text"
+            ]
+        );
+        assert_eq!(input[1]["id"], "call-1");
+        assert_eq!(input[1]["name"], "filesystem-read");
+        assert_eq!(input[1]["arguments"], json!({ "filePath": "package.json" }));
+        assert_eq!(input[2]["call_id"], "call-1");
+        assert_eq!(input[2]["name"], "filesystem-read");
+        assert_eq!(input[2]["result"], json!({ "result": "package result" }));
+        assert_eq!(input[3]["id"], "call-2");
+        assert_eq!(input[4]["call_id"], "call-2");
+        assert!(payload.get("previous_interaction_id").is_none());
+    }
+
+    #[test]
+    fn pairs_repeated_same_name_calls_by_distinct_ids() {
+        let messages = vec![
+            message("user", "Read both", None, None),
+            message(
+                "assistant",
+                "",
+                Some(json!([
+                    {
+                        "type": "function_call",
+                        "id": "first",
+                        "name": "filesystem-read",
+                        "arguments": "{\"filePath\":\"one.txt\"}"
+                    },
+                    {
+                        "type": "function_call",
+                        "id": "second",
+                        "name": "filesystem-read",
+                        "arguments": {}
+                    }
+                ])),
+                None,
+            ),
+            message(
+                "tool",
+                "",
+                None,
+                Some(json!([
+                    { "name": "filesystem-read", "callId": "first", "result": "one" },
+                    { "name": "filesystem-read", "callId": "second", "result": "two" }
+                ])),
+            ),
+        ];
+        let payload = build_interactions_payload(
+            &messages,
+            Path::new("."),
+            &create_test_request(),
+            &create_test_record(""),
+            None,
+            &[],
+        )
+        .expect("Interactions payload");
+        let input = payload["input"].as_array().expect("input array");
+
+        assert_eq!(input[1]["id"], "first");
+        assert_eq!(input[1]["arguments"], json!({ "filePath": "one.txt" }));
+        assert_eq!(input[2]["call_id"], "first");
+        assert_eq!(input[3]["id"], "second");
+        assert_eq!(input[3]["arguments"], json!({}));
+        assert_eq!(input[4]["call_id"], "second");
+    }
+
+    #[test]
+    fn omits_orphan_mismatched_and_malformed_tool_history() {
+        let messages = vec![
+            message("user", "Inspect", None, None),
+            message(
+                "assistant",
+                "",
+                Some(json!([
+                    {
+                        "type": "function_call",
+                        "id": "orphan-call",
+                        "name": "filesystem-read",
+                        "arguments": { "filePath": "missing.txt" }
+                    },
+                    {
+                        "type": "function_call",
+                        "id": "wrong-name",
+                        "name": "filesystem-read",
+                        "arguments": { "filePath": "wrong.txt" }
+                    },
+                    {
+                        "type": "function_call",
+                        "id": "malformed",
+                        "name": "filesystem-read",
+                        "arguments": "{\"filePath\":"
+                    },
+                    {
+                        "type": "function_call",
+                        "id": "missing-result",
+                        "name": "filesystem-read",
+                        "arguments": {}
+                    }
+                ])),
+                None,
+            ),
+            message(
+                "tool",
+                "",
+                None,
+                Some(json!([
+                    { "name": "todo-todo-manage", "callId": "wrong-name", "result": "wrong" },
+                    { "name": "filesystem-read", "callId": "orphan-result", "result": "orphan" },
+                    { "name": "filesystem-read", "callId": "malformed", "result": "unsafe" },
+                    { "name": "filesystem-read", "callId": "missing-result" }
+                ])),
+            ),
+            ChatContextMessage {
+                role: "assistant".to_string(),
+                content: String::new(),
+                tool_calls_json: Some("not-json".to_string()),
+                tool_results_json: None,
+                thinking: None,
+                thinking_blocks_json: None,
+            },
+            ChatContextMessage {
+                role: "tool".to_string(),
+                content: String::new(),
+                tool_calls_json: None,
+                tool_results_json: Some("not-json".to_string()),
+                thinking: None,
+                thinking_blocks_json: None,
+            },
+        ];
+        let mut request = create_test_request();
+        request.previous_response_id = Some("interaction-stateful".to_string());
+        let payload = build_interactions_payload(
+            &messages,
+            Path::new("."),
+            &request,
+            &create_test_record(""),
+            None,
+            &[],
+        )
+        .expect("Interactions payload");
+        let input = payload["input"].as_array().expect("input array");
+
+        assert_eq!(input.len(), 1);
+        assert_eq!(input[0]["type"], "text");
+        assert_eq!(payload["previous_interaction_id"], "interaction-stateful");
+    }
+
+    #[test]
+    fn stateless_pairs_take_precedence_over_previous_interaction_id() {
+        let messages = vec![
+            message("user", "Inspect", None, None),
+            message(
+                "assistant",
+                "",
+                Some(json!([{
+                    "type": "function_call",
+                    "id": "call-1",
+                    "name": "filesystem-read",
+                    "arguments": { "filePath": "package.json" }
+                }])),
+                None,
+            ),
+            message(
+                "tool",
+                "",
+                None,
+                Some(json!([{
+                    "name": "filesystem-read",
+                    "callId": "call-1",
+                    "result": "done"
+                }])),
+            ),
+        ];
+        let mut request = create_test_request();
+        request.previous_response_id = Some("interaction-previous".to_string());
+        let payload = build_interactions_payload(
+            &messages,
+            Path::new("."),
+            &request,
+            &create_test_record(""),
+            None,
+            &[],
+        )
+        .expect("Interactions payload");
+
+        assert!(payload.get("previous_interaction_id").is_none());
+        assert_eq!(payload["input"][1]["type"], "function_call");
+        assert_eq!(payload["input"][2]["type"], "function_result");
+    }
+
+    #[test]
+    fn rejects_result_before_call_without_retroactive_pairing() {
+        let messages = vec![
+            message("user", "Inspect", None, None),
+            message(
+                "tool",
+                "",
+                None,
+                Some(json!([{
+                    "name": "filesystem-read",
+                    "callId": "call-late",
+                    "result": "must not be replayed"
+                }])),
+            ),
+            message(
+                "assistant",
+                "",
+                Some(json!([{
+                    "type": "function_call",
+                    "id": "call-late",
+                    "name": "filesystem-read",
+                    "arguments": {}
+                }])),
+                None,
+            ),
+            message("user", "Continue", None, None),
+        ];
+        let payload = build_interactions_payload(
+            &messages,
+            Path::new("."),
+            &create_test_request(),
+            &create_test_record(""),
+            None,
+            &[],
+        )
+        .expect("Interactions payload");
+        let input = payload["input"].as_array().expect("input array");
+
+        assert_eq!(input.len(), 2);
+        assert!(input.iter().all(|step| {
+            !matches!(
+                step["type"].as_str(),
+                Some("function_call" | "function_result")
+            )
+        }));
+    }
+
+    #[test]
+    fn keeps_each_call_with_its_result_and_images_before_the_next_call() {
+        let messages = vec![
+            message("user", "Inspect", None, None),
+            message(
+                "assistant",
+                "",
+                Some(json!([
+                    {
+                        "type": "function_call",
+                        "id": "image-call",
+                        "name": "browser-screenshot",
+                        "arguments": {}
+                    },
+                    {
+                        "type": "function_call",
+                        "id": "text-call",
+                        "name": "filesystem-read",
+                        "arguments": {}
+                    }
+                ])),
+                None,
+            ),
+            message(
+                "tool",
+                "",
+                None,
+                Some(json!([
+                    {
+                        "name": "browser-screenshot",
+                        "callId": "image-call",
+                        "result": "captured @@image:data:image/png;base64,YQ==@@"
+                    },
+                    {
+                        "name": "filesystem-read",
+                        "callId": "text-call",
+                        "result": "done"
+                    }
+                ])),
+            ),
+        ];
+        let payload = build_interactions_payload(
+            &messages,
+            Path::new("."),
+            &create_test_request(),
+            &create_test_record(""),
+            None,
+            &[],
+        )
+        .expect("Interactions payload");
+        let input = payload["input"].as_array().expect("input array");
+        let types = input
+            .iter()
+            .map(|step| step["type"].as_str().expect("step type"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            types,
+            vec![
+                "text",
+                "function_call",
+                "function_result",
+                "image",
+                "function_call",
+                "function_result"
+            ]
+        );
+        assert_eq!(input[2]["call_id"], "image-call");
+        assert_eq!(
+            input[2]["result"],
+            json!({ "result": "captured [Image #1]" })
+        );
+        assert_eq!(input[3]["inline_data"]["mime_type"], "image/png");
+        assert_eq!(input[3]["inline_data"]["data"], "YQ==");
+        assert_eq!(input[4]["id"], "text-call");
+        assert_eq!(input[5]["call_id"], "text-call");
+    }
+}

--- a/native/src/api/interactions/stream.rs
+++ b/native/src/api/interactions/stream.rs
@@ -1,0 +1,398 @@
+//! Google Interactions streaming response collection.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use napi::bindgen_prelude::*;
+use napi::threadsafe_function::ThreadsafeFunctionCallMode;
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT_ENCODING, CONTENT_TYPE};
+use serde_json::Value;
+use tokio_util::sync::CancellationToken;
+
+use crate::api::common::{emit_stream_chunk, emit_tool_args_probe, inject_custom_headers};
+use crate::api::responses::{ResponsesApiStreamCallback, ResponsesApiStreamChunk};
+use crate::api::retry::{
+    decide_stream_recovery, should_retry, stream_idle_timeout_error, visible_content_char_count,
+    wait_before_retry, RetryOptions, StreamAttemptProgress, StreamEndCause,
+    StreamInterruptionReason, StreamRecoveryDecision, StreamRecoveryOutcome,
+};
+use crate::api::sse::{read_sse_stream_until_terminal, SseStreamEnd};
+use crate::storage::services::chat_conversations::ChatTokenUsage;
+
+pub(super) struct InteractionsStreamResult {
+    pub id: String,
+    pub content: String,
+    pub thinking: String,
+    pub model: String,
+    pub status: String,
+    pub interruption_reason: Option<StreamInterruptionReason>,
+    pub recovery_outcome: Option<StreamRecoveryOutcome>,
+    pub token_usage: ChatTokenUsage,
+    pub tool_calls_json: String,
+    pub total_duration_ms: i64,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn collect_interactions_stream(
+    client: &reqwest::Client,
+    endpoint: &str,
+    custom_headers: &HashMap<String, String>,
+    payload: Value,
+    on_chunk: &ResponsesApiStreamCallback,
+    cancel_token: &CancellationToken,
+    retry_options: &RetryOptions,
+    stream_idle_timeout_sec: u64,
+) -> Result<InteractionsStreamResult> {
+    let mut attempt: u32 = 0;
+    let mut stream_token_count: usize = 0;
+    let stream_start = std::time::Instant::now();
+    let mut ttft_ms: i64 = 0;
+    let idle_timeout = Duration::from_secs(stream_idle_timeout_sec);
+
+    'attempt_loop: loop {
+        if cancel_token.is_cancelled() {
+            return Ok(InteractionsStreamResult {
+                id: String::new(),
+                content: String::new(),
+                thinking: String::new(),
+                model: String::new(),
+                status: String::from("cancelled"),
+                interruption_reason: None,
+                recovery_outcome: None,
+                token_usage: ChatTokenUsage::default(),
+                tool_calls_json: "[]".to_string(),
+                total_duration_ms: stream_start.elapsed().as_millis() as i64,
+            });
+        }
+
+        let response = loop {
+            if cancel_token.is_cancelled() {
+                return Ok(InteractionsStreamResult {
+                    id: String::new(),
+                    content: String::new(),
+                    thinking: String::new(),
+                    model: String::new(),
+                    status: String::from("cancelled"),
+                    interruption_reason: None,
+                    recovery_outcome: None,
+                    token_usage: ChatTokenUsage::default(),
+                    tool_calls_json: "[]".to_string(),
+                    total_duration_ms: stream_start.elapsed().as_millis() as i64,
+                });
+            }
+
+            let send_future = client
+                .post(endpoint)
+                .headers(build_header_map(custom_headers)?)
+                .json(&payload)
+                .send();
+
+            let result = tokio::select! {
+                biased;
+                _ = cancel_token.cancelled() => {
+                    return Ok(InteractionsStreamResult {
+                        id: String::new(),
+                        content: String::new(),
+                        thinking: String::new(),
+                        model: String::new(),
+                        status: String::from("cancelled"),
+                        interruption_reason: None,
+                        recovery_outcome: None,
+                        token_usage: ChatTokenUsage::default(),
+                        tool_calls_json: "[]".to_string(),
+                        total_duration_ms: stream_start.elapsed().as_millis() as i64,
+                    });
+                }
+                result = send_future => {
+                    result.map_err(|error| {
+                        let category = if error.is_timeout() {
+                            "network timeout"
+                        } else if error.is_connect() {
+                            "network connection error"
+                        } else {
+                            "network request error"
+                        };
+                        Error::from_reason(format!("Failed to create Interactions stream: {category}"))
+                    })
+                }
+            };
+
+            match result {
+                Ok(response) => {
+                    let status = response.status();
+                    if !status.is_success() {
+                        let error_text = response
+                            .text()
+                            .await
+                            .unwrap_or_else(|_| "Failed to read response body".to_string());
+                        let error_text = super::event::bounded_provider_error_response(&error_text);
+                        let error = Error::from_reason(format!(
+                            "Interactions stream request failed: {status} {error_text}"
+                        ));
+
+                        if !should_retry(&error, attempt, retry_options) {
+                            return Err(error);
+                        }
+
+                        on_chunk.call(
+                            ResponsesApiStreamChunk {
+                                content_delta: String::new(),
+                                thinking_delta: String::new(),
+                                content: String::new(),
+                                thinking: String::new(),
+                                retrying: true,
+                                retry_attempt: Some((attempt + 1) as i32),
+                                retry_error: Some(error.reason.clone()),
+                                stream_token_count: stream_token_count as i64,
+                                elapsed_ms: stream_start.elapsed().as_millis() as i64,
+                                ttft_ms,
+                                vision_status: None,
+                            },
+                            ThreadsafeFunctionCallMode::NonBlocking,
+                        );
+
+                        match wait_before_retry(retry_options, cancel_token, attempt).await {
+                            Ok(()) => {
+                                attempt += 1;
+                                continue;
+                            }
+                            Err(err) => return Err(err),
+                        }
+                    }
+                    break response;
+                }
+                Err(error) => {
+                    if !should_retry(&error, attempt, retry_options) {
+                        return Err(error);
+                    }
+
+                    on_chunk.call(
+                        ResponsesApiStreamChunk {
+                            content_delta: String::new(),
+                            thinking_delta: String::new(),
+                            content: String::new(),
+                            thinking: String::new(),
+                            retrying: true,
+                            retry_attempt: Some((attempt + 1) as i32),
+                            retry_error: Some(error.reason.clone()),
+                            stream_token_count: stream_token_count as i64,
+                            elapsed_ms: stream_start.elapsed().as_millis() as i64,
+                            ttft_ms,
+                            vision_status: None,
+                        },
+                        ThreadsafeFunctionCallMode::NonBlocking,
+                    );
+
+                    match wait_before_retry(retry_options, cancel_token, attempt).await {
+                        Ok(()) => {
+                            attempt += 1;
+                            continue;
+                        }
+                        Err(err) => return Err(err),
+                    }
+                }
+            }
+        };
+
+        let mut content_chunks: Vec<String> = Vec::new();
+        let mut thinking_chunks: Vec<String> = Vec::new();
+        let mut raw_events: Vec<Value> = Vec::new();
+        let mut tool_calls = super::event::InteractionsToolCallState::default();
+        let mut response_id = String::new();
+        let mut response_model = String::new();
+        let mut response_status = String::from("in_progress");
+        let mut provider_failure = None;
+        let mut token_usage = ChatTokenUsage::default();
+        let mut byte_buffer: Vec<u8> = Vec::new();
+        let mut stream_finished = false;
+        let mut interruption_reason = None;
+        let mut recovery_outcome = None;
+        let mut stream = response.bytes_stream();
+        let mut end_cause: Option<(StreamEndCause, String)> = None;
+
+        macro_rules! process_event_block {
+            ($event_block:expr) => {{
+                let content_start_index = content_chunks.len();
+                let thinking_start_index = thinking_chunks.len();
+                let mut tool_args_delta = String::new();
+                super::event::process_interactions_sse_event_block(
+                    $event_block,
+                    &mut raw_events,
+                    &mut content_chunks,
+                    &mut thinking_chunks,
+                    &mut tool_calls,
+                    &mut response_id,
+                    &mut response_model,
+                    &mut response_status,
+                    &mut token_usage,
+                    &mut tool_args_delta,
+                    &mut stream_finished,
+                    &mut provider_failure,
+                );
+                let content_delta = content_chunks[content_start_index..].join("");
+                let thinking_delta = thinking_chunks[thinking_start_index..].join("");
+                if ttft_ms == 0 {
+                    ttft_ms = stream_start.elapsed().as_millis() as i64;
+                }
+                emit_stream_chunk(
+                    on_chunk,
+                    content_delta,
+                    thinking_delta,
+                    &mut stream_token_count,
+                    stream_start.elapsed().as_millis() as i64,
+                    ttft_ms,
+                );
+                emit_tool_args_probe(
+                    on_chunk,
+                    &mut stream_token_count,
+                    &tool_args_delta,
+                    stream_start.elapsed().as_millis() as i64,
+                    ttft_ms,
+                );
+            }};
+        }
+
+        let stream_end = read_sse_stream_until_terminal(
+            &mut stream,
+            &mut byte_buffer,
+            cancel_token,
+            idle_timeout,
+            |event_block| {
+                process_event_block!(event_block);
+                stream_finished
+            },
+        )
+        .await;
+
+        match stream_end {
+            SseStreamEnd::ProviderTerminal => {
+                stream_finished = true;
+            }
+            SseStreamEnd::ReadError(error) => {
+                end_cause = Some((StreamEndCause::ReadError, error.to_string()));
+            }
+            SseStreamEnd::UnexpectedEof => {
+                end_cause = Some((
+                    StreamEndCause::UnexpectedEof,
+                    "Stream ended before an Interactions terminal event".to_string(),
+                ));
+            }
+            SseStreamEnd::IdleTimeout => {
+                end_cause = Some((
+                    StreamEndCause::IdleTimeout,
+                    stream_idle_timeout_error().reason.clone(),
+                ));
+            }
+            SseStreamEnd::Cancelled => {
+                response_status = String::from("cancelled");
+            }
+        }
+
+        if response_status == "cancelled" || cancel_token.is_cancelled() {
+            response_status = String::from("cancelled");
+            tool_calls.clear();
+            interruption_reason = None;
+            recovery_outcome = None;
+        } else if let Some(failure) = provider_failure {
+            tool_calls.clear();
+            return Err(Error::from_reason(failure.reason()));
+        } else if stream_finished {
+            recovery_outcome = None;
+        } else {
+            let (cause, retry_error) = end_cause.unwrap_or((
+                StreamEndCause::UnexpectedEof,
+                "Stream ended before an Interactions terminal event".to_string(),
+            ));
+            let progress = StreamAttemptProgress {
+                visible_content_chars: visible_content_char_count(&content_chunks),
+                has_tool_state: tool_calls.has_tool_state(),
+                has_pending_tool_fragments: tool_calls.has_pending_tool_fragments(),
+                provider_terminal: stream_finished,
+                user_cancelled: cancel_token.is_cancelled(),
+            };
+            let decision = decide_stream_recovery(cause, attempt, retry_options, progress);
+
+            match decision {
+                StreamRecoveryDecision::Cancelled => {
+                    response_status = String::from("cancelled");
+                    tool_calls.clear();
+                    interruption_reason = None;
+                    recovery_outcome = None;
+                }
+                StreamRecoveryDecision::FinishProviderResult => {}
+                StreamRecoveryDecision::Retry => {
+                    on_chunk.call(
+                        ResponsesApiStreamChunk {
+                            content_delta: String::new(),
+                            thinking_delta: String::new(),
+                            content: String::new(),
+                            thinking: String::new(),
+                            retrying: true,
+                            retry_attempt: Some((attempt + 1) as i32),
+                            retry_error: Some(retry_error),
+                            stream_token_count: stream_token_count as i64,
+                            elapsed_ms: stream_start.elapsed().as_millis() as i64,
+                            ttft_ms,
+                            vision_status: None,
+                        },
+                        ThreadsafeFunctionCallMode::NonBlocking,
+                    );
+
+                    match wait_before_retry(retry_options, cancel_token, attempt).await {
+                        Ok(()) => {
+                            attempt += 1;
+                            continue 'attempt_loop;
+                        }
+                        Err(_wait_error) if cancel_token.is_cancelled() => {
+                            response_status = String::from("cancelled");
+                            tool_calls.clear();
+                            interruption_reason = None;
+                            recovery_outcome = None;
+                        }
+                        Err(wait_error) => return Err(wait_error),
+                    }
+                }
+                StreamRecoveryDecision::KeepUsablePartial
+                | StreamRecoveryDecision::SurfaceInterrupted => {
+                    response_status = String::from("incomplete");
+                    interruption_reason = Some(cause.interruption_reason());
+                    recovery_outcome = decision.recovery_outcome();
+                    if matches!(decision, StreamRecoveryDecision::SurfaceInterrupted) {
+                        tool_calls.clear();
+                    }
+                }
+            }
+        }
+
+        let content = content_chunks.join("").trim().to_string();
+        let thinking = thinking_chunks.join("").trim().to_string();
+        let finalized_tool_calls = tool_calls.finalized_tool_calls();
+        let tool_calls_json =
+            serde_json::to_string(&finalized_tool_calls).unwrap_or_else(|_| "[]".to_string());
+
+        return Ok(InteractionsStreamResult {
+            id: response_id,
+            content,
+            thinking,
+            model: response_model,
+            status: response_status,
+            interruption_reason,
+            recovery_outcome,
+            token_usage,
+            tool_calls_json,
+            total_duration_ms: stream_start.elapsed().as_millis() as i64,
+        });
+    }
+}
+
+fn build_header_map(custom_headers: &HashMap<String, String>) -> Result<HeaderMap> {
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    headers.insert(ACCEPT_ENCODING, HeaderValue::from_static("identity"));
+    inject_custom_headers(
+        &mut headers,
+        custom_headers,
+        &["authorization", "x-goog-api-key"],
+    )?;
+    Ok(headers)
+}

--- a/native/src/api/mod.rs
+++ b/native/src/api/mod.rs
@@ -11,6 +11,7 @@ pub mod embedding;
 pub mod file_search_agent;
 pub mod gemini;
 pub mod http_client;
+pub mod interactions;
 pub mod models;
 pub mod reranking;
 pub mod responses;

--- a/native/src/api/models.rs
+++ b/native/src/api/models.rs
@@ -356,7 +356,7 @@ pub fn fetch_available_models(
     let is_default_base_url = base_url == DEFAULT_OPENAI_BASE_URL;
 
     let mut models = match config.request_method.as_str() {
-        "gemini" => {
+        "gemini" | "interactions" => {
             let gemini_base_url = if is_default_base_url {
                 DEFAULT_GEMINI_BASE_URL.to_string()
             } else {

--- a/native/src/api/responses/mod.rs
+++ b/native/src/api/responses/mod.rs
@@ -88,6 +88,13 @@ pub struct ResponsesApiRequest {
     /// system prompt. Used by lightweight single-shot completions (e.g. AI
     /// commit-message generation).
     pub skip_context: Option<bool>,
+    /// Preserve normal context while omitting MCP tools for this request.
+    /// Used to recover from a provider that repeated completed readonly calls.
+    pub disable_tools: Option<bool>,
+    /// Request-local instruction used only to recover a repeated-tool turn.
+    /// It is applied as a provider system instruction and is never persisted
+    /// as a conversation message or reused for sub-agent semantics.
+    pub internal_recovery_prompt: Option<String>,
     /// When true, replace the built-in system prompt with the Plan Mode prompt
     /// that instructs the AI to plan and get user approval before executing.
     pub plan_mode: Option<bool>,
@@ -309,7 +316,10 @@ async fn create_response_async(
     )
     .await?;
 
-    let tools = if request.context_compaction.unwrap_or(false) || skip_context {
+    let tools = if request.context_compaction.unwrap_or(false)
+        || skip_context
+        || request.disable_tools.unwrap_or(false)
+    {
         None
     } else {
         match resolve_sub_agent_tools(&request).await {

--- a/native/src/api/responses/payload.rs
+++ b/native/src/api/responses/payload.rs
@@ -307,6 +307,17 @@ pub(super) fn build_responses_payload(
     } else if !builtin_system_parts.is_empty() {
         instructions = Some(builtin_system_parts.join("\n\n"));
     }
+    if let Some(prompt) = request
+        .internal_recovery_prompt
+        .as_deref()
+        .map(str::trim)
+        .filter(|prompt| !prompt.is_empty())
+    {
+        instructions = Some(match instructions {
+            Some(existing) => format!("{existing}\n\n{prompt}"),
+            None => prompt.to_string(),
+        });
+    }
 
     if input.is_empty() {
         return Err(Error::from_reason("Chat message content is required"));

--- a/native/src/api/summary.rs
+++ b/native/src/api/summary.rs
@@ -9,11 +9,11 @@ use crate::api::config::{
 };
 use crate::api::responses::payload::build_responses_reasoning;
 use crate::api::retry::{should_retry, RetryOptions};
+use crate::storage::initialize_app_storage;
 use crate::storage::services::app_logs::maybe_log_api_request;
 use crate::storage::services::chat_conversations::{
     get_conversation_api_profile, load_context_messages, update_conversation_summary,
 };
-use crate::storage::initialize_app_storage;
 use napi::bindgen_prelude::*;
 use reqwest::header::{
     HeaderMap, HeaderName, HeaderValue, ACCEPT_ENCODING, AUTHORIZATION, CONTENT_TYPE,
@@ -121,7 +121,7 @@ pub async fn generate_conversation_summary(
                     &messages,
                     &retry_options,
                 ).await,
-                "gemini" => generate_summary_via_gemini(
+                "gemini" | "interactions" => generate_summary_via_gemini(
                     &database_path,
                     &api_config,
                     &api_key,
@@ -360,8 +360,7 @@ async fn generate_summary_via_gemini(
             "parts": [{"text": user_content}]
         }],
         "generationConfig": {
-            "maxOutputTokens": 4096,
-            "thinkingConfig": {"thinkingBudget": 0}
+            "maxOutputTokens": 4096
         }
     });
 

--- a/native/src/api/theme_palette.rs
+++ b/native/src/api/theme_palette.rs
@@ -85,6 +85,8 @@ fn build_request(image_data_url: &str) -> ResponsesApiRequest {
         // tag into their native multimodal payloads. An empty conversation_id
         // ensures no chat history is loaded.
         skip_context: None,
+        disable_tools: None,
+        internal_recovery_prompt: None,
         plan_mode: None,
         goal_mode: None,
         worktree_mode: None,

--- a/native/src/api/theme_palette.rs
+++ b/native/src/api/theme_palette.rs
@@ -270,8 +270,19 @@ pub async fn generate_theme_palette_stream(
             )
             .await
         }
+        "interactions" => {
+            crate::api::interactions::create_interactions_response_stream(
+                request,
+                database_path,
+                api_config,
+                custom_headers,
+                on_chunk,
+                cancel_token,
+            )
+            .await
+        }
         request_method => Err(Error::from_reason(format!(
-            "Unsupported request method '{}'. Please switch the selected API request method to Chat, Responses, Anthropic or Gemini.",
+            "Unsupported request method '{}'. Please switch the selected API request method to Chat, Responses, Anthropic, Gemini, or Interactions.",
             request_method
         ))),
     };

--- a/native/src/api/vision/mod.rs
+++ b/native/src/api/vision/mod.rs
@@ -58,7 +58,7 @@ pub fn should_textify_images(api_config: &ApiConfigRecord) -> bool {
 
     matches!(
         request_method,
-        "chat" | "responses" | "anthropic" | "gemini"
+        "chat" | "responses" | "anthropic" | "gemini" | "interactions"
     )
 }
 

--- a/native/src/api/vision/providers.rs
+++ b/native/src/api/vision/providers.rs
@@ -45,17 +45,24 @@ pub(crate) async fn describe_image(
     }
 
     let result = match vision_config.request_method.as_str() {
-        "chat" => describe_image_via_chat(client, vision_config, image, user_prompt, cancel_token).await?,
+        "chat" => {
+            describe_image_via_chat(client, vision_config, image, user_prompt, cancel_token).await?
+        }
         "responses" => {
-            describe_image_via_responses(client, vision_config, image, user_prompt, cancel_token).await?
+            describe_image_via_responses(client, vision_config, image, user_prompt, cancel_token)
+                .await?
         }
         "anthropic" => {
-            describe_image_via_anthropic(client, vision_config, image, user_prompt, cancel_token).await?
+            describe_image_via_anthropic(client, vision_config, image, user_prompt, cancel_token)
+                .await?
         }
-        "gemini" => describe_image_via_gemini(client, vision_config, image, user_prompt, cancel_token).await?,
+        "gemini" | "interactions" => {
+            describe_image_via_gemini(client, vision_config, image, user_prompt, cancel_token)
+                .await?
+        }
         method => {
             return Err(Error::from_reason(format!(
-                "Unsupported vision request method: {method}. Supported: chat, responses, anthropic, gemini."
+                "Unsupported vision request method: {method}. Supported: chat, responses, anthropic, gemini, interactions."
             )));
         }
     };
@@ -245,12 +252,14 @@ async fn describe_image_via_gemini(
         }],
         "generationConfig": {
             "maxOutputTokens": vision_config.max_tokens,
-            // 思考开关：默认关闭（thinkingBudget=0），开启时给 1024 预算
-            "thinkingConfig": {
-                "thinkingBudget": if vision_config.thinking_enabled { 1024 } else { 0 },
-            },
         },
     });
+
+    if vision_config.thinking_enabled {
+        payload["generationConfig"]["thinkingConfig"] = json!({
+            "thinkingBudget": 1024
+        });
+    }
 
     // 谷歌搜索联网（Gemini 原生 grounding）：配置开启时注入 google_search 工具
     if vision_config.google_search {
@@ -449,11 +458,7 @@ async fn send_vision_stream(
     use futures::StreamExt;
 
     let response = {
-        let send_future = client
-            .post(endpoint)
-            .headers(headers)
-            .json(payload)
-            .send();
+        let send_future = client.post(endpoint).headers(headers).json(payload).send();
         match cancel_token {
             Some(token) => tokio::select! {
                 biased;

--- a/native/src/mcp/servers/browser/mod.rs
+++ b/native/src/mcp/servers/browser/mod.rs
@@ -240,7 +240,7 @@ impl McpService for BrowserService {
                             "maximum": 200
                         },
                         "requestId": {
-                            "type": ["string", "number"],
+                            "type": "string",
                             "description": "Network request reference. For networkDetails: CDP request id from the network list (string). For network_detail: the numeric id of the request to retrieve full details for (use network action first to obtain ids)."
                         },
                         "maxBodyBytes": {
@@ -279,6 +279,7 @@ impl McpService for BrowserService {
                             "additionalProperties": { "type": "string" }
                         },
                         "dialogResponse": {
+                            "type": "object",
                             "description": "Response for the dialog action: { accept: boolean, promptText?: string }. When provided, the most recent pending dialog is answered instead of listing dialogs.",
                             "properties": {
                                 "accept": {

--- a/native/src/mcp/tools/mod.rs
+++ b/native/src/mcp/tools/mod.rs
@@ -10,9 +10,7 @@ use crate::mcp::servers::bash::stream_io::emit_stream_chunk;
 use crate::mcp::servers::bash::BashStreamCallback;
 use crate::storage::services::checkpoint::remote::RemoteCheckpointClient;
 use crate::storage::services::checkpoint::CheckpointWorktreeCapture;
-use crate::storage::services::system_settings::{
-    McpGlobalScopeSettings, McpProjectScopeSettings,
-};
+use crate::storage::services::system_settings::{McpGlobalScopeSettings, McpProjectScopeSettings};
 
 enum ToolCheckpointCapture {
     None,
@@ -44,8 +42,8 @@ enum ToolCheckpointOperationGuard {
 
 use super::builtin::{get_builtin_servers_with_tools, get_builtin_tools};
 use super::servers::remote_workspace::{
-    is_ssh_path, is_windows_absolute_path, RemoteWorkspaceCallback, resolve_remote_project_workspace,
-    resolve_remote_workspace_path,
+    is_ssh_path, is_windows_absolute_path, resolve_remote_project_workspace,
+    resolve_remote_workspace_path, RemoteWorkspaceCallback,
 };
 
 mod call;
@@ -54,16 +52,16 @@ mod plan_write;
 mod result_limit;
 mod serialize;
 
-pub use call::call_mcp_tool;
-pub use collect::{collect_all_mcp_tools, collect_allowed_mcp_tools};
-pub use serialize::{
-    tools_as_anthropic_json, tools_as_gemini_json, tools_as_openai_chat_json,
-    tools_as_openai_responses_json,
-};
 pub use super::servers::sub_agents::SUB_AGENT_COMMS_TOOL_FULL_NAMES;
+pub use call::call_mcp_tool;
 pub(crate) use collect::{
     builtin_scope_server_id, builtin_server_name, load_global_scope, load_project_scope,
     server_id_from_tool_name, with_database_path,
+};
+pub use collect::{collect_all_mcp_tools, collect_allowed_mcp_tools};
+pub use serialize::{
+    tools_as_anthropic_json, tools_as_gemini_json, tools_as_interactions_json,
+    tools_as_openai_chat_json, tools_as_openai_responses_json,
 };
 
 // NOTE: list_mcp_tools 和 call_mcp_tool 的 #[napi] 导出在 exports/api.rs 中，
@@ -171,9 +169,7 @@ pub async fn list_mcp_tools() -> napi::Result<Vec<McpToolDefinition>> {
     Ok(to_tool_definitions(&tools))
 }
 
-pub async fn list_mcp_server_tools(
-    config_server_id: String,
-) -> napi::Result<Vec<McpToolStatus>> {
+pub async fn list_mcp_server_tools(config_server_id: String) -> napi::Result<Vec<McpToolStatus>> {
     let tools = super::external::discover_server_tools(None, &config_server_id, true).await?;
     let global_scope = load_global_scope().await?;
     Ok(to_tool_statuses(&tools, global_scope.as_ref()))
@@ -666,9 +662,7 @@ fn remote_workspace_path_field(tool_full_name: &str) -> Option<&'static str> {
         "filesystem-read" | "filesystem-replace_edit" | "filesystem-create" => Some("filePath"),
         name if name.starts_with("codelens-") => Some("filePath"),
         "grep-search" => Some("path"),
-        "bash-terminal-execute" => {
-            Some("workingDirectory")
-        }
+        "bash-terminal-execute" => Some("workingDirectory"),
         _ => None,
     }
 }
@@ -812,10 +806,9 @@ async fn acquire_tool_checkpoint_operation_guard(
                 })?;
             // 先等同文件锁，再进入目录共享锁：等待同文件的调用不会长期占住
             // 目录读锁，回滚可在两次文件编辑之间公平取得独占锁。
-            let file_lock =
-                crate::storage::services::checkpoint::checkpoint_file_operation_lock(
-                    work_dir, file_path,
-                )?;
+            let file_lock = crate::storage::services::checkpoint::checkpoint_file_operation_lock(
+                work_dir, file_path,
+            )?;
             let file_guard = file_lock.lock_owned().await;
             let work_dir_lock =
                 crate::storage::services::checkpoint::checkpoint_operation_lock(work_dir)?;
@@ -866,9 +859,7 @@ fn capture_checkpoint_before_tool(
     }
     // 先定范围再校验 work_dir，Skill / 外部 MCP 不被前置阶段阻断。
     match tool_checkpoint_scope(tool_full_name) {
-        ToolCheckpointScope::None | ToolCheckpointScope::Unknown => {
-            Ok(ToolCheckpointCapture::None)
-        }
+        ToolCheckpointScope::None | ToolCheckpointScope::Unknown => Ok(ToolCheckpointCapture::None),
         ToolCheckpointScope::File => {
             let work_dir = require_checkpoint_work_dir(checkpoint_work_dir)?;
             let file_path = args
@@ -944,9 +935,7 @@ async fn capture_checkpoint_before_tool_remote(
     }
     // 先定范围再校验 work_dir（与本地版本一致），Skill / 外部 MCP 不阻断。
     match tool_checkpoint_scope(tool_full_name) {
-        ToolCheckpointScope::None | ToolCheckpointScope::Unknown => {
-            Ok(ToolCheckpointCapture::None)
-        }
+        ToolCheckpointScope::None | ToolCheckpointScope::Unknown => Ok(ToolCheckpointCapture::None),
         ToolCheckpointScope::File => {
             // 单文件回滚语义保持不变：记录失败按工具错误上抛。
             let work_dir = require_checkpoint_work_dir(checkpoint_work_dir)?;
@@ -1007,8 +996,7 @@ async fn capture_checkpoint_before_tool_remote(
             // SFTP 遍历可能很慢：使用独立超时上限（不与命令 timeout 挂钩），
             // 超时/失败软失败降级，并通知 Electron 中止仍在进行的扫描。
             let scan_id = uuid::Uuid::new_v4().to_string();
-            let client =
-                RemoteCheckpointClient::with_scan_id(on_remote_workspace_command, scan_id);
+            let client = RemoteCheckpointClient::with_scan_id(on_remote_workspace_command, scan_id);
             let started = Instant::now();
             emit_stream_chunk(
                 on_chunk,
@@ -1104,8 +1092,7 @@ async fn capture_checkpoint_after_tool_remote(
             // 命令已结束：after 失败只意味着变更记录不完整，软失败降级，
             // 不能把已成功的命令结果覆盖为失败（避免模型重试）。
             let scan_id = uuid::Uuid::new_v4().to_string();
-            let client =
-                RemoteCheckpointClient::with_scan_id(on_remote_workspace_command, scan_id);
+            let client = RemoteCheckpointClient::with_scan_id(on_remote_workspace_command, scan_id);
             let started = Instant::now();
             if on_chunk.is_some() {
                 warn(crate::i18n::fill(
@@ -1164,8 +1151,7 @@ fn capture_checkpoint_after_tool(capture: ToolCheckpointCapture) -> napi::Result
         ToolCheckpointCapture::Worktree(Some(capture)) => {
             // 软失败：after 记录失败只意味着回滚保护可能不完整，不能把
             // 已经成功的工具结果覆盖为失败（避免模型重试已执行的命令）。
-            match crate::storage::services::checkpoint::record_checkpoint_worktree_after(capture)
-            {
+            match crate::storage::services::checkpoint::record_checkpoint_worktree_after(capture) {
                 Ok(()) => Ok(()),
                 Err(error) => {
                     eprintln!(
@@ -1250,19 +1236,72 @@ fn is_readonly_single_statement(statement: &str) -> bool {
     // 任意命令，无法静态判定），均保守保留 checkpoint。
     const READONLY_PATTERNS: &[&str] = &[
         // 纯读命令（可带参数）
-        "echo", "ls", "pwd", "grep", "rg", "cat", "head", "tail", "wc",
-        "sort", "uniq", "find", "which", "type", "date", "printf",
-        "dirname", "basename", "readlink", "realpath", "stat", "file",
-        "tree", "du", "df", "nproc", "uname", "hostname", "ps", "top",
-        "ping", "nslookup", "dig", "history", "jobs", "true", "false",
-        "sleep", "test", "[", "exit", "cd", "export", "unset", "set",
+        "echo",
+        "ls",
+        "pwd",
+        "grep",
+        "rg",
+        "cat",
+        "head",
+        "tail",
+        "wc",
+        "sort",
+        "uniq",
+        "find",
+        "which",
+        "type",
+        "date",
+        "printf",
+        "dirname",
+        "basename",
+        "readlink",
+        "realpath",
+        "stat",
+        "file",
+        "tree",
+        "du",
+        "df",
+        "nproc",
+        "uname",
+        "hostname",
+        "ps",
+        "top",
+        "ping",
+        "nslookup",
+        "dig",
+        "history",
+        "jobs",
+        "true",
+        "false",
+        "sleep",
+        "test",
+        "[",
+        "exit",
+        "cd",
+        "export",
+        "unset",
+        "set",
         // git 只读子命令（写类子命令 add/commit/push/pull/checkout 等不在列）
-        "git status", "git log", "git diff", "git branch", "git rev-parse",
-        "git remote", "git show", "git ls-files", "git tag", "git blame",
-        "git reflog", "git describe", "git shortlog", "git config --get",
+        "git status",
+        "git log",
+        "git diff",
+        "git branch",
+        "git rev-parse",
+        "git remote",
+        "git show",
+        "git ls-files",
+        "git tag",
+        "git blame",
+        "git reflog",
+        "git describe",
+        "git shortlog",
+        "git config --get",
         "git help",
         // 只读网络探测
-        "curl -I", "curl -i", "curl -sI", "wget --spider",
+        "curl -I",
+        "curl -i",
+        "curl -sI",
+        "wget --spider",
     ];
 
     READONLY_PATTERNS.iter().any(|pattern| {
@@ -1382,7 +1421,11 @@ fn split_shell_statements(command: &str) -> Option<Vec<&str>> {
                 start = i + 1;
             }
             b'&' => {
-                let sep_len = if bytes.get(i + 1) == Some(&b'&') { 2 } else { 1 };
+                let sep_len = if bytes.get(i + 1) == Some(&b'&') {
+                    2
+                } else {
+                    1
+                };
                 statements.push(&command[start..i]);
                 start = i + sep_len;
                 i += sep_len - 1;
@@ -1495,8 +1538,7 @@ fn remote_bash_checkpoint_skip_reason(
                 dir: working_directory.to_string(),
             });
         }
-        let Some((authority, segments)) = plan_write::normalize_ssh_path(working_directory)
-        else {
+        let Some((authority, segments)) = plan_write::normalize_ssh_path(working_directory) else {
             return None; // 无法解析时保守保留扫描
         };
         if authority != workspace_authority
@@ -1551,9 +1593,7 @@ fn command_targets_outside_workspace(
         // 可能写入的语句：按 cwd 位置与绝对路径证据判断写入位置。
         let cwd_inside_or_uncertain = match &cwd {
             None => true,
-            Some(segments) => {
-                plan_write::remote_segments_start_with(segments, workspace_segments)
-            }
+            Some(segments) => plan_write::remote_segments_start_with(segments, workspace_segments),
         };
         let Some(tokens) = tokenize_shell_tokens(statement) else {
             return false; // 无法解析 → 保守保留扫描

--- a/native/src/mcp/tools/serialize.rs
+++ b/native/src/mcp/tools/serialize.rs
@@ -21,21 +21,54 @@ pub fn tools_as_openai_chat_json(tools: &[McpTool]) -> Value {
     Value::Array(functions)
 }
 
-/// Tool APIs require the root input schema to describe an object. Some
-/// compatible gateways reject root `oneOf`/`anyOf`/`allOf` combinators when a
-/// branch does not explicitly declare an object, even if the root has
-/// `type: "object"`. Keep nested constraints intact, but remove root
-/// combinators and always emit an object schema. Runtime tool validation still
-/// enforces cross-field requirements that cannot be represented at the root.
+/// Tool APIs require input schemas to describe an object. Some gateways (e.g.
+/// Google Gemini API, OpenAI, Claude) strictly enforce that any schema node with
+/// `properties` or `required` MUST declare `"type": "object"`, any node with
+/// `items` MUST declare `"type": "array"`, and `type` cannot be a union array.
+/// Remove root combinators (`oneOf`/`anyOf`/`allOf`) and recursively ensure all
+/// nested schema nodes are compliant.
 fn sanitize_tool_input_schema(schema: &Value) -> Value {
-    let mut result = schema.as_object().cloned().unwrap_or_default();
+    let mut root = schema.clone();
+    sanitize_schema_node(&mut root, true);
+    root
+}
 
-    result.remove("oneOf");
-    result.remove("anyOf");
-    result.remove("allOf");
-    result.insert("type".to_string(), Value::String("object".to_string()));
+fn sanitize_schema_node(node: &mut Value, is_root: bool) {
+    if let Value::Object(map) = node {
+        if is_root {
+            map.remove("oneOf");
+            map.remove("anyOf");
+            map.remove("allOf");
+            map.insert("type".to_string(), Value::String("object".to_string()));
+        } else if let Some(type_val) = map.get("type") {
+            if let Some(arr) = type_val.as_array() {
+                let first_scalar = arr
+                    .iter()
+                    .find_map(|item| item.as_str())
+                    .unwrap_or("string");
+                map.insert(
+                    "type".to_string(),
+                    Value::String(first_scalar.to_string()),
+                );
+            }
+        } else if map.contains_key("properties") || map.contains_key("required") {
+            map.insert("type".to_string(), Value::String("object".to_string()));
+        } else if map.contains_key("items") {
+            map.insert("type".to_string(), Value::String("array".to_string()));
+        }
 
-    Value::Object(result)
+        if let Some(properties) = map.get_mut("properties") {
+            if let Value::Object(props_map) = properties {
+                for (_, prop_val) in props_map.iter_mut() {
+                    sanitize_schema_node(prop_val, false);
+                }
+            }
+        }
+
+        if let Some(items) = map.get_mut("items") {
+            sanitize_schema_node(items, false);
+        }
+    }
 }
 
 pub fn tools_as_anthropic_json(tools: &[McpTool]) -> Value {
@@ -91,4 +124,59 @@ pub fn tools_as_gemini_json(tools: &[McpTool]) -> Value {
     json!([{
         "functionDeclarations": function_declarations
     }])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitizes_nested_schemas_and_fixes_missing_types_for_gemini() {
+        let raw_schema = json!({
+            "oneOf": [{"type": "object"}],
+            "properties": {
+                "dialogResponse": {
+                    "description": "A dialog response object without explicit type",
+                    "properties": {
+                        "accept": { "type": "boolean" },
+                        "promptText": { "type": "string" }
+                    },
+                    "required": ["accept"]
+                },
+                "requestId": {
+                    "type": ["string", "number"],
+                    "description": "Union type"
+                },
+                "itemsList": {
+                    "items": {
+                        "properties": {
+                            "name": { "type": "string" }
+                        }
+                    }
+                }
+            }
+        });
+
+        let sanitized = sanitize_tool_input_schema(&raw_schema);
+
+        assert_eq!(sanitized["type"], "object");
+        assert!(sanitized.get("oneOf").is_none());
+
+        // dialogResponse has properties, so type: "object" must be injected
+        assert_eq!(sanitized["properties"]["dialogResponse"]["type"], "object");
+        assert_eq!(
+            sanitized["properties"]["dialogResponse"]["properties"]["accept"]["type"],
+            "boolean"
+        );
+
+        // requestId array type collapsed to single scalar string
+        assert_eq!(sanitized["properties"]["requestId"]["type"], "string");
+
+        // itemsList items object has properties, so type: "object" injected into item, and itemsList has type: "array"
+        assert_eq!(sanitized["properties"]["itemsList"]["type"], "array");
+        assert_eq!(
+            sanitized["properties"]["itemsList"]["items"]["type"],
+            "object"
+        );
+    }
 }

--- a/native/src/mcp/tools/serialize.rs
+++ b/native/src/mcp/tools/serialize.rs
@@ -46,10 +46,7 @@ fn sanitize_schema_node(node: &mut Value, is_root: bool) {
                     .iter()
                     .find_map(|item| item.as_str())
                     .unwrap_or("string");
-                map.insert(
-                    "type".to_string(),
-                    Value::String(first_scalar.to_string()),
-                );
+                map.insert("type".to_string(), Value::String(first_scalar.to_string()));
             }
         } else if map.contains_key("properties") || map.contains_key("required") {
             map.insert("type".to_string(), Value::String("object".to_string()));
@@ -126,9 +123,41 @@ pub fn tools_as_gemini_json(tools: &[McpTool]) -> Value {
     }])
 }
 
+pub fn tools_as_interactions_json(tools: &[McpTool]) -> Value {
+    let function_declarations: Vec<Value> = tools
+        .iter()
+        .map(|tool| {
+            let sanitized_schema = sanitize_tool_input_schema(&tool.input_schema);
+            json!({
+                "name": tool.full_name(),
+                "description": tool.description,
+                "parameters": sanitized_schema,
+            })
+        })
+        .collect();
+
+    json!([{
+        "function_declarations": function_declarations
+    }])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_tool(server_id: &str, name: &str, required_field: &str) -> McpTool {
+        McpTool {
+            server_id: server_id.to_string(),
+            name: name.to_string(),
+            description: format!("Tool requiring {required_field}"),
+            input_schema: json!({
+                "properties": {
+                    required_field: { "type": "string" }
+                },
+                "required": [required_field]
+            }),
+        }
+    }
 
     #[test]
     fn sanitizes_nested_schemas_and_fixes_missing_types_for_gemini() {
@@ -178,5 +207,57 @@ mod tests {
             sanitized["properties"]["itemsList"]["items"]["type"],
             "object"
         );
+    }
+
+    #[test]
+    fn serializes_interactions_tools_as_one_grouped_compatibility_object() {
+        let tools = vec![
+            test_tool("todo", "todo-manage", "action"),
+            test_tool("filesystem", "read", "filePath"),
+        ];
+
+        let serialized = tools_as_interactions_json(&tools);
+        let entries = serialized.as_array().expect("Interactions tools array");
+        let declarations = entries[0]["function_declarations"]
+            .as_array()
+            .expect("Interactions function declarations");
+
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].get("type").is_none());
+        assert_eq!(declarations.len(), 2);
+        assert_eq!(declarations[0]["name"], "todo-todo-manage");
+        assert_eq!(declarations[0]["parameters"]["type"], "object");
+        assert_eq!(declarations[0]["parameters"]["required"], json!(["action"]));
+        assert_eq!(
+            declarations[0]["parameters"]["properties"]["action"]["type"],
+            "string"
+        );
+        assert_eq!(declarations[1]["name"], "filesystem-read");
+        assert_eq!(
+            declarations[1]["parameters"]["required"],
+            json!(["filePath"])
+        );
+        assert!(declarations
+            .iter()
+            .all(|declaration| declaration.get("type").is_none()));
+        assert!(entries[0].get("functionDeclarations").is_none());
+    }
+
+    #[test]
+    fn keeps_native_gemini_tools_grouped() {
+        let serialized = tools_as_gemini_json(&[test_tool("filesystem", "read", "filePath")]);
+        let entries = serialized.as_array().expect("Gemini tools array");
+        let declarations = entries[0]["functionDeclarations"]
+            .as_array()
+            .expect("Gemini function declarations");
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(declarations.len(), 1);
+        assert_eq!(declarations[0]["name"], "filesystem-read");
+        assert_eq!(
+            declarations[0]["parameters"]["required"],
+            json!(["filePath"])
+        );
+        assert!(entries[0].get("type").is_none());
     }
 }

--- a/native/src/storage/services/app_logs.rs
+++ b/native/src/storage/services/app_logs.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
-use rusqlite::{params, Row};
+use rusqlite::{params, params_from_iter, types::Value, Row};
 
 use super::super::database;
 use super::system_settings;
@@ -88,25 +88,21 @@ pub fn list_app_logs(
     let safe_limit = if limit > 0 { limit } else { 100 };
     let safe_offset = if offset > 0 { offset } else { 0 };
 
-    let filter_level = !level.trim().is_empty();
-    let filter_module = !module.trim().is_empty();
-    let filter_since = !since.trim().is_empty();
-    let filter_until = !until.trim().is_empty();
-
     database::open_connection(database_path)
         .and_then(|connection| {
             let mut where_clauses: Vec<String> = Vec::new();
-            if filter_level {
-                where_clauses.push("level = ?1".to_string());
-            }
-            if filter_module {
-                where_clauses.push("module = ?2".to_string());
-            }
-            if filter_since {
-                where_clauses.push("created_at >= ?3".to_string());
-            }
-            if filter_until {
-                where_clauses.push("created_at <= ?4".to_string());
+            let mut filter_values = Vec::new();
+            for (column, operator, raw_value) in [
+                ("level", "=", level),
+                ("module", "=", module),
+                ("created_at", ">=", since),
+                ("created_at", "<=", until),
+            ] {
+                let value = raw_value.trim();
+                if !value.is_empty() {
+                    where_clauses.push(format!("{column} {operator} ?"));
+                    filter_values.push(Value::Text(value.to_string()));
+                }
             }
             let where_sql = if where_clauses.is_empty() {
                 String::new()
@@ -114,15 +110,10 @@ pub fn list_app_logs(
                 format!(" WHERE {}", where_clauses.join(" AND "))
             };
 
-            let level_param = level.trim();
-            let module_param = module.trim();
-            let since_param = since.trim();
-            let until_param = until.trim();
-
             let count_sql = format!("SELECT COUNT(*) FROM app_logs{where_sql}");
             let total: i32 = connection.query_row(
                 &count_sql,
-                params![level_param, module_param, since_param, until_param],
+                params_from_iter(filter_values.iter()),
                 |row| row.get(0),
             )?;
 
@@ -131,21 +122,14 @@ pub fn list_app_logs(
                         input, output, duration, context, error, source, created_at
                    FROM app_logs{where_sql}
                   ORDER BY created_at DESC, id DESC
-                  LIMIT ?5 OFFSET ?6"
+                  LIMIT ? OFFSET ?"
             );
 
+            let mut list_values = filter_values;
+            list_values.push(Value::Integer(i64::from(safe_limit)));
+            list_values.push(Value::Integer(i64::from(safe_offset)));
             let mut statement = connection.prepare(&list_sql)?;
-            let rows = statement.query_map(
-                params![
-                    level_param,
-                    module_param,
-                    since_param,
-                    until_param,
-                    safe_limit,
-                    safe_offset
-                ],
-                map_log_row,
-            )?;
+            let rows = statement.query_map(params_from_iter(list_values.iter()), map_log_row)?;
 
             let items: Vec<AppLogRecord> = rows.collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(AppLogPage { items, total })
@@ -209,7 +193,8 @@ pub fn log_api_error(database_path: &Path, func: &str, message: &str, error: &st
 /// - `database_path`: path to the SQLite database file.
 /// - `provider`: short provider tag ("chat", "gemini", "responses",
 ///   "anthropic", "embedding", "reranking").
-/// - `endpoint`: the full request URL.
+/// - `endpoint`: the full request URL. Credential query values are redacted
+///   before persistence.
 /// - `payload_json`: serialized request body JSON.
 ///
 /// Failures (disabled flag read errors, insert errors) are silently
@@ -222,7 +207,7 @@ pub async fn maybe_log_api_request(
 ) {
     let db_path = database_path;
     let provider = provider;
-    let endpoint = endpoint;
+    let endpoint = redact_request_endpoint(&endpoint);
     let payload_json = payload_json;
 
     tokio::task::spawn_blocking(move || {
@@ -263,6 +248,119 @@ pub async fn maybe_log_api_request(
     })
     .await
     .ok();
+}
+
+const REDACTED_QUERY_VALUE: &str = "[REDACTED]";
+const ENCODED_REDACTED_QUERY_VALUE: &str = "%5BREDACTED%5D";
+
+fn redact_request_endpoint(endpoint: &str) -> String {
+    let Ok(mut url) = reqwest::Url::parse(endpoint) else {
+        return redact_malformed_request_endpoint(endpoint);
+    };
+
+    let mut contains_sensitive_value = false;
+    let query_pairs = url
+        .query_pairs()
+        .map(|(name, value)| {
+            let value = if is_sensitive_query_name(&name) {
+                contains_sensitive_value = true;
+                REDACTED_QUERY_VALUE.to_string()
+            } else {
+                value.into_owned()
+            };
+            (name.into_owned(), value)
+        })
+        .collect::<Vec<_>>();
+
+    if !contains_sensitive_value {
+        return endpoint.to_string();
+    }
+
+    url.query_pairs_mut()
+        .clear()
+        .extend_pairs(query_pairs.iter().map(|(name, value)| (name, value)));
+    url.to_string()
+}
+
+fn redact_malformed_request_endpoint(endpoint: &str) -> String {
+    let Some((prefix, remainder)) = endpoint.split_once('?') else {
+        return "[INVALID ENDPOINT]".to_string();
+    };
+    let (query, fragment) = remainder
+        .split_once('#')
+        .map_or((remainder, None), |(query, fragment)| {
+            (query, Some(fragment))
+        });
+
+    let mut contains_sensitive_value = false;
+    let redacted_query = query
+        .split('&')
+        .map(|component| {
+            let raw_name = component
+                .split_once('=')
+                .map_or(component, |(name, _)| name);
+            if decoded_query_name(raw_name)
+                .as_deref()
+                .is_some_and(is_sensitive_query_name)
+            {
+                contains_sensitive_value = true;
+                format!("{raw_name}={ENCODED_REDACTED_QUERY_VALUE}")
+            } else {
+                component.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("&");
+
+    if !contains_sensitive_value {
+        return endpoint.to_string();
+    }
+
+    let fragment = fragment.map_or_else(String::new, |value| format!("#{value}"));
+    format!("{prefix}?{redacted_query}{fragment}")
+}
+
+fn decoded_query_name(raw_name: &str) -> Option<String> {
+    let probe = reqwest::Url::parse(&format!(
+        "https://request-log-redaction.invalid/?{raw_name}="
+    ))
+    .ok()?;
+    probe
+        .query_pairs()
+        .next()
+        .map(|(name, _)| name.into_owned())
+}
+
+fn is_sensitive_query_name(name: &str) -> bool {
+    let canonical_name = name
+        .trim()
+        .chars()
+        .filter(|character| !matches!(character, '_' | '-'))
+        .flat_map(char::to_lowercase)
+        .collect::<String>();
+
+    matches!(
+        canonical_name.as_str(),
+        "key"
+            | "apikey"
+            | "xapikey"
+            | "xgoogapikey"
+            | "token"
+            | "authtoken"
+            | "bearertoken"
+            | "accesstoken"
+            | "refreshtoken"
+            | "idtoken"
+            | "sessiontoken"
+            | "authorization"
+            | "auth"
+            | "signature"
+            | "secret"
+            | "clientsecret"
+            | "password"
+            | "credential"
+            | "credentials"
+    )
 }
 
 /// Write a hook warning log when a hook command exits with code 1 (soft warning).
@@ -324,4 +422,108 @@ fn map_log_row(row: &Row<'_>) -> rusqlite::Result<AppLogRecord> {
         source: row.get(11)?,
         created_at: row.get(12)?,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact_request_endpoint;
+
+    #[test]
+    fn request_endpoint_redacts_sensitive_aliases_case_insensitively() {
+        let endpoint = concat!(
+            "https://api.example.test/v1/models?",
+            "key=first&API_KEY=second&api-key=third&token=fourth&",
+            "access_token=fifth&refresh-token=sixth&Authorization=seventh&",
+            "signature=eighth&secret=ninth&password=tenth&key=eleventh&",
+            "x-api-key=twelfth&x-goog-api-key=thirteenth&auth_token=fourteenth&",
+            "bearer-token=fifteenth&client_secret=sixteenth&credential=seventeenth"
+        );
+
+        let redacted = redact_request_endpoint(endpoint);
+        let url = reqwest::Url::parse(&redacted).expect("redacted endpoint should remain valid");
+        let pairs = url.query_pairs().collect::<Vec<_>>();
+
+        assert_eq!(pairs.len(), 17);
+        assert!(pairs.iter().all(|(_, value)| value == "[REDACTED]"));
+        for secret in [
+            "first",
+            "second",
+            "third",
+            "fourth",
+            "fifth",
+            "sixth",
+            "seventh",
+            "eighth",
+            "ninth",
+            "tenth",
+            "eleventh",
+            "twelfth",
+            "thirteenth",
+            "fourteenth",
+            "fifteenth",
+            "sixteenth",
+            "seventeenth",
+        ] {
+            assert!(!redacted.contains(secret));
+        }
+    }
+
+    #[test]
+    fn request_endpoint_decodes_encoded_names_and_preserves_diagnostics() {
+        let endpoint = concat!(
+            "https://api.example.test/v1beta/interactions?",
+            "%61pi%5Fkey=credential&model=gemini-3.7&region=us-west#trace"
+        );
+
+        let redacted = redact_request_endpoint(endpoint);
+        let url = reqwest::Url::parse(&redacted).expect("redacted endpoint should remain valid");
+        let pairs = url.query_pairs().collect::<Vec<_>>();
+
+        assert_eq!(url.scheme(), "https");
+        assert_eq!(url.host_str(), Some("api.example.test"));
+        assert_eq!(url.path(), "/v1beta/interactions");
+        assert_eq!(url.fragment(), Some("trace"));
+        assert_eq!(pairs[0].1, "[REDACTED]");
+        assert_eq!(pairs[1], ("model".into(), "gemini-3.7".into()));
+        assert_eq!(pairs[2], ("region".into(), "us-west".into()));
+        assert!(!redacted.contains("credential"));
+    }
+
+    #[test]
+    fn request_endpoint_leaves_non_sensitive_query_names_unchanged() {
+        let endpoint = concat!(
+            "https://api.example.test/v1?monkey=capuchin&",
+            "tokenizer=sentencepiece&secret_mode=disabled&signature_version=v4"
+        );
+
+        assert_eq!(redact_request_endpoint(endpoint), endpoint);
+    }
+
+    #[test]
+    fn malformed_endpoint_redacts_encoded_and_duplicate_sensitive_values() {
+        let endpoint = concat!(
+            "not a valid endpoint?%41ccess%5FToken=first&mode=debug&",
+            "%61ccess_token=second#diagnostic"
+        );
+
+        let redacted = redact_request_endpoint(endpoint);
+
+        assert_eq!(
+            redacted,
+            concat!(
+                "not a valid endpoint?%41ccess%5FToken=%5BREDACTED%5D&mode=debug&",
+                "%61ccess_token=%5BREDACTED%5D#diagnostic"
+            )
+        );
+        assert!(!redacted.contains("first"));
+        assert!(!redacted.contains("second"));
+    }
+
+    #[test]
+    fn malformed_endpoint_without_query_is_not_persisted_verbatim() {
+        assert_eq!(
+            redact_request_endpoint("not a valid endpoint containing a credential"),
+            "[INVALID ENDPOINT]"
+        );
+    }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,7 +92,7 @@ importers:
         version: 9.12.4
       '@types/markdown-it':
         specifier: ^14.1.2
-        version: 14.1.2
+        version: 14.2.0
       '@types/node':
         specifier: ^24.3.0
         version: 24.13.3
@@ -120,9 +120,9 @@ importers:
       electron-vite:
         specifier: ^4.0.0
         version: 4.0.0(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.11))
-      tsx:
-        specifier: ^4.23.11
-        version: 4.23.11
+      prettier:
+        specifier: ^3.9.6
+        version: 3.9.6
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
@@ -1555,8 +1555,8 @@ packages:
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
 
-  '@types/markdown-it@14.1.2':
-    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+  '@types/markdown-it@14.2.0':
+    resolution: {integrity: sha512-NoQ2yGlLWj4wpxMs+TYmRKk3thDrQ97agr7sFqfLsAlvoS8SNQuTrlObhFqG9iugdTtgOE9jpJ6FNM4ZGsa5xQ==}
 
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
@@ -2830,6 +2830,11 @@ packages:
   postject@1.0.0-alpha.6:
     resolution: {integrity: sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==}
     engines: {node: '>=14.0.0'}
+    hasBin: true
+
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
+    engines: {node: '>=14'}
     hasBin: true
 
   proc-log@6.0.0:
@@ -4607,7 +4612,7 @@ snapshots:
 
   '@types/linkify-it@5.0.0': {}
 
-  '@types/markdown-it@14.1.2':
+  '@types/markdown-it@14.2.0':
     dependencies:
       '@types/linkify-it': 5.0.0
       '@types/mdurl': 2.0.0
@@ -6053,6 +6058,8 @@ snapshots:
       commander: 9.4.0
     optional: true
 
+  prettier@3.9.6: {}
+
   proc-log@6.0.0: {}
 
   process-nextick-args@2.0.1: {}
@@ -6377,6 +6384,7 @@ snapshots:
       esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
+    optional: true
 
   tunnel@0.0.6:
     optional: true

--- a/src/main/ipc/handlers/chatHandlers.ts
+++ b/src/main/ipc/handlers/chatHandlers.ts
@@ -107,6 +107,15 @@ const normalizeResponsesApiRequest = (value: unknown): ResponsesApiRequest => {
         : undefined,
     skipContext:
       typeof source.skipContext === "boolean" ? source.skipContext : undefined,
+    disableTools:
+      typeof source.disableTools === "boolean"
+        ? source.disableTools
+        : undefined,
+    internalRecoveryPrompt:
+      typeof source.internalRecoveryPrompt === "string" &&
+      source.internalRecoveryPrompt.trim()
+        ? source.internalRecoveryPrompt
+        : undefined,
     planMode:
       typeof source.planMode === "boolean" ? source.planMode : undefined,
     goalMode:

--- a/src/main/native/types.ts
+++ b/src/main/native/types.ts
@@ -964,6 +964,10 @@ export type ResponsesApiRequest = {
   subAgentSystemPrompt?: string;
   subAgentConfigProfile?: string;
   skipContext?: boolean;
+  /** Preserve normal conversation context but omit MCP tools for this request. */
+  disableTools?: boolean;
+  /** Request-local recovery instruction. Never persisted as a chat message. */
+  internalRecoveryPrompt?: string;
   planMode?: boolean;
   goalMode?: boolean;
   worktreeMode?: boolean;

--- a/src/preload/types/api.ts
+++ b/src/preload/types/api.ts
@@ -80,6 +80,13 @@ export type ResponsesApiRequest = {
   subAgentSystemPrompt?: string | null;
   subAgentConfigProfile?: string | null;
   skipContext?: boolean | null;
+  /** Preserve normal conversation context but omit MCP tools for this request. */
+  disableTools?: boolean | null;
+  /**
+   * Request-local instruction used for internal recovery. It is included with
+   * provider system instructions, never persisted as a conversation message.
+   */
+  internalRecoveryPrompt?: string | null;
   planMode?: boolean | null;
   goalMode?: boolean | null;
   worktreeMode?: boolean | null;

--- a/src/renderer/components/mainContent/chatInput/constants.ts
+++ b/src/renderer/components/mainContent/chatInput/constants.ts
@@ -38,6 +38,13 @@ export const THINKING_OPTIONS_BY_METHOD: Record<
     { value: "medium", label: "Medium", icon: Activity },
     { value: "high", label: "High", icon: BrainCircuit },
   ],
+  interactions: [
+    { value: "none", label: "None", icon: CircleOff },
+    { value: "minimal", label: "Minimal", icon: CircleDot },
+    { value: "low", label: "Low", icon: Gauge },
+    { value: "medium", label: "Medium", icon: Activity },
+    { value: "high", label: "High", icon: BrainCircuit },
+  ],
   responses: [
     { value: "none", label: "None", icon: CircleOff },
     { value: "low", label: "Low", icon: Gauge },

--- a/src/renderer/components/mainContent/chatInput/types.ts
+++ b/src/renderer/components/mainContent/chatInput/types.ts
@@ -102,7 +102,7 @@ export type ChatInputProps = {
   isCompacting?: boolean;
 };
 
-export type RequestMethod = "chat" | "responses" | "gemini" | "anthropic";
+export type RequestMethod = "chat" | "responses" | "gemini" | "anthropic" | "interactions";
 
 /** 模型选择菜单的二级视图。 */
 export type ModelMenuView = "root" | "model" | "thinking" | "apiProfile";

--- a/src/renderer/components/mainContent/chatMessages/hooks/agentLoopHelpers.ts
+++ b/src/renderer/components/mainContent/chatMessages/hooks/agentLoopHelpers.ts
@@ -143,18 +143,10 @@ export const resetRunStreamMetrics = (
   ctx.updateSessionField(sessionKey, "runTokenUsage", null);
   const refSession = ctx.sessionsRefData.current.get(sessionKey);
   if (refSession) {
+    refSession.iterationTokenCount = 0;
+    refSession.iterationElapsedMs = 0;
     refSession.runTokenUsage = null;
   }
-};
-
-/** Finalize the previous iteration and prepare counters for the next request. */
-export const beginStreamMetricsIteration = (
-  ctx: ConversationContextValue,
-  sessionKey: string
-): void => {
-  ctx.updateSessionField(sessionKey, "streamTokenCount", 0);
-  ctx.updateSessionField(sessionKey, "streamElapsedMs", 0);
-  ctx.updateSessionField(sessionKey, "streamTtftMs", 0);
 };
 
 /** Accumulate a single-request usage into the run-level totals. Each
@@ -280,6 +272,10 @@ export const createStreamChunkHandler = (
   assistantMessageId: string,
   isCancelled: () => boolean
 ) => {
+  const refSession = ctx.sessionsRefData.current.get(sessionKey);
+  const iterationTokenBase = refSession?.iterationTokenCount ?? 0;
+  const iterationElapsedBase = refSession?.iterationElapsedMs ?? 0;
+
   return (chunk: ResponsesApiStreamChunk): void => {
     // External-vision textify progress event: update the session-level
     // visionAnalysis field only, never touch message content. The backend
@@ -319,13 +315,20 @@ export const createStreamChunkHandler = (
       return;
     }
 
-    ctx.updateSessionField(
-      sessionKey,
-      "streamTokenCount",
-      chunk.streamTokenCount
-    );
-    ctx.updateSessionField(sessionKey, "streamElapsedMs", chunk.elapsedMs);
-    ctx.updateSessionField(sessionKey, "streamTtftMs", chunk.ttftMs);
+    const runTokenCount = iterationTokenBase + chunk.streamTokenCount;
+    const runElapsedMs = iterationElapsedBase + chunk.elapsedMs;
+    ctx.updateSessionField(sessionKey, "streamTokenCount", runTokenCount);
+    ctx.updateSessionField(sessionKey, "streamElapsedMs", runElapsedMs);
+    if (refSession) {
+      refSession.iterationTokenCount = runTokenCount;
+      refSession.iterationElapsedMs = runElapsedMs;
+    }
+    if (
+      chunk.ttftMs > 0 &&
+      (ctx.sessionsRef.current[sessionKey]?.streamTtftMs ?? 0) === 0
+    ) {
+      ctx.updateSessionField(sessionKey, "streamTtftMs", chunk.ttftMs);
+    }
     if (
       chunk.ttftMs > 0 &&
       (ctx.sessionsRef.current[sessionKey]?.runTtftMs ?? 0) === 0

--- a/src/renderer/components/mainContent/chatMessages/hooks/subAgentActivation.ts
+++ b/src/renderer/components/mainContent/chatMessages/hooks/subAgentActivation.ts
@@ -33,7 +33,6 @@ import {
   PARENT_PLAN_APPROVAL_REQUIRED,
   accumulateConversationRunStats,
   accumulateRunTokenUsage,
-  beginStreamMetricsIteration,
   createStreamChunkHandler,
   createStreamIdHandler,
   resetRunStreamMetrics,
@@ -273,7 +272,6 @@ const createSubAgentRunLoop = (deps: SubAgentRunLoopDeps): SubAgentRunLoop => {
       subAssistantMessage,
     ]);
 
-    beginStreamMetricsIteration(ctx, subConvId);
     const subStreamPromise = window.snow.createResponseStream(
       {
         messages: subMessages,

--- a/src/renderer/components/mainContent/chatMessages/hooks/toolExecution.ts
+++ b/src/renderer/components/mainContent/chatMessages/hooks/toolExecution.ts
@@ -293,6 +293,7 @@ export function createToolExecutor(
     const startParallelTool = async (idx: number): Promise<boolean> => {
       const parallelToolCall = toolCalls[idx];
       const isSubAgent = parallelToolCall.name === "sub-agents-activate";
+      const isImageGen = parallelToolCall.name === "imagegen-generate";
 
       // Mark running immediately so each card shows live progress while
       // the others are still working.
@@ -471,7 +472,7 @@ export function createToolExecutor(
             })
           );
 
-          if (!isSubAgent) {
+          if (isImageGen) {
             activeImageGenCount--;
             // 腾出的并发槽位立即补位：启动等待队列中的下一个生图请求。
             while (pendingImageGenQueue.length > 0) {
@@ -491,15 +492,39 @@ export function createToolExecutor(
       return true;
     };
 
+    // The native registry is the source of truth for side-effect-free tools.
+    // Keep todo/config mutations out even if a future registry entry is too
+    // broad: only todo "get" and config get/list are safe to overlap.
+    let readonlyToolNames = new Set<string>();
+    try {
+      readonlyToolNames = new Set(await window.snow.listReadonlyTools());
+    } catch {
+      // Preserve the existing specialized parallel paths if the registry is
+      // unavailable during startup or native bridge recovery.
+    }
+    const isTodoReadAction = (toolCall: ToolCallInfo): boolean => {
+      try {
+        return (
+          (JSON.parse(toolCall.arguments || "{}") as { action?: unknown })
+            .action === "get"
+        );
+      } catch {
+        return false;
+      }
+    };
+
     const parallelIndices: number[] = [];
     for (let i = 0; i < toolCalls.length; i++) {
       const name = toolCalls[i].name;
       const isParallelizable =
         name === "sub-agents-activate" || name === "imagegen-generate";
+      const isReadonlyTool =
+        readonlyToolNames.has(name) &&
+        (name !== "todo-todo-manage" || isTodoReadAction(toolCalls[i]));
       const skipPendingSubAgent =
         name === "sub-agents-activate" && isPendingSessionKey(effectiveKey);
       if (
-        isParallelizable &&
+        (isParallelizable || isReadonlyTool) &&
         !skipPendingSubAgent &&
         authorizationDecisions[i].status !== "rejected" &&
         !validateToolCall(toolCalls[i])
@@ -526,11 +551,15 @@ export function createToolExecutor(
       // 启动 maxConcurrentImageGen 个，其余排队，完成一个补一个。
       for (const idx of parallelIndices) {
         const isSubAgent = toolCalls[idx].name === "sub-agents-activate";
-        if (isSubAgent || activeImageGenCount < maxConcurrentImageGen) {
+        if (
+          isSubAgent ||
+          toolCalls[idx].name !== "imagegen-generate" ||
+          activeImageGenCount < maxConcurrentImageGen
+        ) {
           if (!(await startParallelTool(idx))) {
             break;
           }
-          if (!isSubAgent) {
+          if (toolCalls[idx].name === "imagegen-generate") {
             activeImageGenCount++;
           }
         } else {

--- a/src/renderer/components/mainContent/chatMessages/hooks/useAgentLoop.ts
+++ b/src/renderer/components/mainContent/chatMessages/hooks/useAgentLoop.ts
@@ -30,7 +30,6 @@ import {
 import {
   accumulateConversationRunStats,
   accumulateRunTokenUsage,
-  beginStreamMetricsIteration,
   createAwaitHookDecision,
   createIsRunCancelled,
   createStreamChunkHandler,
@@ -451,10 +450,6 @@ export const useAgentLoop = (params: UseAgentLoopParams) => {
             return;
           }
         }
-
-        // Carry the completed iteration into the run totals, then reset the
-        // per-request probes before starting the next model stream.
-        beginStreamMetricsIteration(ctx, effectiveKey);
 
         // Capture the stream promise so rollback can await it before issuing
         // delete/truncate. Without this, the Rust store_chat_exchange write

--- a/src/renderer/components/mainContent/chatMessages/hooks/useAgentLoop.ts
+++ b/src/renderer/components/mainContent/chatMessages/hooks/useAgentLoop.ts
@@ -18,6 +18,7 @@ import {
   formatToolResultsContent,
   getErrorMessage,
   parseToolCalls,
+  updateFirstMatchingToolCall,
 } from "../utils/conversationHelpers";
 import { resolveResponseDisposition } from "../utils/responseDisposition";
 import {
@@ -43,6 +44,18 @@ import {
 import { createToolExecutor } from "./toolExecution";
 
 type CapturedChatInputSendOptions = ChatInputSendOptions;
+
+// A completed read can only become stale when a tool may have changed the
+// workspace. Session bookkeeping (for example todo updates) must not make a
+// previously completed filesystem read executable again.
+const WORKSPACE_MUTATING_TOOL_NAMES = new Set([
+  "filesystem-create",
+  "filesystem-replace_edit",
+  "bash-terminal-execute",
+]);
+
+const mayMutateWorkspace = (toolCall: ToolCallInfo): boolean =>
+  WORKSPACE_MUTATING_TOOL_NAMES.has(toolCall.name);
 
 const captureChatInputSendOptions = (
   options: ChatInputSendOptions,
@@ -94,6 +107,81 @@ const persistPendingConversationRuntimeConfig = (
       .catch(recordFailure);
   } catch (error) {
     recordFailure(error);
+  }
+};
+
+const normalizeWorkspacePath = (
+  filePath: string,
+  workspacePath?: string,
+): string => {
+  const normalizedPath = filePath.replace(/\\/g, "/").replace(/\/+$/, "") || ".";
+  const normalizedWorkspace = workspacePath
+    ?.replace(/\\/g, "/")
+    .replace(/\/+$/, "");
+  if (!normalizedWorkspace) {
+    return normalizedPath;
+  }
+
+  const isWindowsPath = /^[a-z]:\//i.test(normalizedWorkspace);
+  const comparablePath = isWindowsPath
+    ? normalizedPath.toLowerCase()
+    : normalizedPath;
+  const comparableWorkspace = isWindowsPath
+    ? normalizedWorkspace.toLowerCase()
+    : normalizedWorkspace;
+  if (normalizedPath === ".") {
+    return "<workspace>";
+  }
+  if (normalizedPath.startsWith("./")) {
+    return `<workspace>/${normalizedPath.slice(2)}`;
+  }
+  if (comparablePath === comparableWorkspace) {
+    return "<workspace>";
+  }
+  if (comparablePath.startsWith(`${comparableWorkspace}/`)) {
+    return `<workspace>/${normalizedPath.slice(normalizedWorkspace.length + 1)}`;
+  }
+  return normalizedPath;
+};
+
+const canonicalizeToolArguments = (
+  argumentsJson: string,
+  toolName?: string,
+  workspacePath?: string,
+): string | null => {
+  try {
+    const sortJson = (value: unknown): unknown => {
+      if (Array.isArray(value)) {
+        return value.map(sortJson);
+      }
+      if (value && typeof value === "object") {
+        return Object.fromEntries(
+          Object.entries(value as Record<string, unknown>)
+            .sort(([left], [right]) => left.localeCompare(right))
+            .map(([key, child]) => [key, sortJson(child)]),
+        );
+      }
+      return value;
+    };
+    const parsed = JSON.parse(argumentsJson || "{}") as Record<string, unknown>;
+    if (
+      toolName === "filesystem-read" &&
+      typeof parsed.filePath === "string"
+    ) {
+      parsed.filePath = normalizeWorkspacePath(parsed.filePath, workspacePath);
+    }
+    return JSON.stringify(sortJson(parsed));
+  } catch {
+    return null;
+  }
+};
+
+const isFailedToolResult = (result: string): boolean => {
+  try {
+    const parsed = JSON.parse(result) as Record<string, unknown>;
+    return parsed.success === false || typeof parsed.error === "string";
+  } catch {
+    return false;
   }
 };
 
@@ -395,6 +483,51 @@ export const useAgentLoop = (params: UseAgentLoopParams) => {
 
       const awaitHookDecision = createAwaitHookDecision(ctx);
 
+      // A provider can resend a successful read with a fresh call ID. Keep
+      // this state scoped to one agent run, so a later user message starts
+      // clean while a write within this run deliberately permits a re-read.
+      const completedReadonlyCalls = new Set<string>();
+      let duplicateRecoveryAttempted = false;
+      const workspacePath =
+        directoryIdToPath(sessionDirId) ?? ctx.directoryPath;
+      let readonlyToolNamesPromise: Promise<Set<string>> | undefined;
+      const getReadonlyToolNames = (): Promise<Set<string>> => {
+        readonlyToolNamesPromise ??= window.snow
+          .listReadonlyTools()
+          .then((names) => new Set(names))
+          .catch(() => new Set<string>());
+        return readonlyToolNamesPromise;
+      };
+      const isReadonlyCall = (
+        toolCall: ToolCallInfo,
+        readonlyToolNames: Set<string>,
+      ): boolean => {
+        if (!readonlyToolNames.has(toolCall.name)) {
+          return false;
+        }
+        if (toolCall.name !== "todo-todo-manage") {
+          return true;
+        }
+        try {
+          return (
+            (JSON.parse(toolCall.arguments || "{}") as { action?: unknown })
+              .action === "get"
+          );
+        } catch {
+          return false;
+        }
+      };
+      const readonlyCallKey = (toolCall: ToolCallInfo): string | null => {
+        const argumentsJson = canonicalizeToolArguments(
+          toolCall.arguments,
+          toolCall.name,
+          workspacePath,
+        );
+        return argumentsJson === null
+          ? null
+          : `${toolCall.name}:${argumentsJson}`;
+      };
+
       const executeSubAgentActivation = createSubAgentActivation({
         ctx,
         requestToolAuthorizations,
@@ -428,6 +561,12 @@ export const useAgentLoop = (params: UseAgentLoopParams) => {
         // backend builds the request context from the database and treats
         // requestMessages as a placeholder (never sent nor persisted).
         resumeAfterCompaction?: boolean,
+        // A one-shot recovery continuation preserves history and tool results,
+        // but asks every provider to omit its outbound tools array.
+        disableTools = false,
+        // Request-local system-level recovery instruction. This deliberately
+        // does not become a conversation message or persisted user content.
+        internalRecoveryPrompt?: string,
       ): Promise<void> => {
         const iterSessionKey = currentConversationId ?? sessionKey;
         let effectiveKey = iterSessionKey;
@@ -471,6 +610,8 @@ export const useAgentLoop = (params: UseAgentLoopParams) => {
             directoryId: sessionDirId,
             checkpointId,
             resumeAfterCompaction,
+            disableTools,
+            internalRecoveryPrompt,
             planMode: iterRef?.planMode ?? ctx.planModeRef.current,
             goalMode: iterRef?.goalMode ?? ctx.goalModeRef.current,
             worktreeMode: iterRef?.worktreeMode ?? ctx.worktreeModeRef.current,
@@ -990,11 +1131,105 @@ export const useAgentLoop = (params: UseAgentLoopParams) => {
           return;
         }
 
-        // A tool-call response must always be processed into tool results and
-        // followed by another model request. The loop naturally finishes only
-        // when a later response contains no tool calls, or when the user cancels.
+        // A provider that returns calls after tools were deliberately omitted
+        // has violated the request contract. Record the calls for auditability
+        // but do not authorize, execute, or recurse into another loop.
+        if (disableTools) {
+          const ignoredResult = JSON.stringify({
+            success: false,
+            error: "TOOLS_DISABLED_FOR_DUPLICATE_RECOVERY",
+            message:
+              "Tools were disabled for this recovery request because equivalent read-only calls already completed. No tool was executed.",
+          });
+          ctx.updateSessionMessages(effectiveKey, (currentMessages) =>
+            currentMessages.map((currentMessage) =>
+              currentMessage.id === currentAssistantMessageId
+                ? {
+                    ...currentMessage,
+                    toolCalls: toolCalls.map((toolCall) => ({
+                      ...toolCall,
+                      status: "completed" as const,
+                      result: ignoredResult,
+                    })),
+                  }
+                : currentMessage,
+            ),
+          );
+          if (response.conversationId) {
+            await window.snow.appendToolMessage(
+              response.conversationId,
+              formatToolResultsContent(
+                toolCalls.map((toolCall) => ({
+                  name: toolCall.name,
+                  callId: toolCall.callId || "",
+                  result: ignoredResult,
+                })),
+              ),
+            );
+          }
+          ctx.pendingQueueRef.current.delete(effectiveKey);
+          ctx.setActivePendingMessages([]);
+          return;
+        }
+
+        // Tool calls are normally processed into results and followed by
+        // another model request. A batch made entirely of repeated successful
+        // readonly calls is terminal: its duplicate results are persisted, but
+        // sending them back to a provider that already ignored the prior result
+        // would only create an unbounded request loop.
+        const readonlyToolNames = await getReadonlyToolNames();
+        const duplicateReadonlyResults = new Map<ToolCallInfo, string>();
+        const executableToolCalls = toolCalls.filter((toolCall) => {
+          const key = readonlyCallKey(toolCall);
+          if (
+            key === null ||
+            !isReadonlyCall(toolCall, readonlyToolNames) ||
+            !completedReadonlyCalls.has(key)
+          ) {
+            return true;
+          }
+
+          const result = JSON.stringify({
+            success: false,
+            error: "DUPLICATE_READONLY_TOOL_CALL",
+            message:
+              "This read-only tool call already completed with identical arguments during this agent run, and no mutating tool has executed since. Use the prior tool result and finish the task without repeating the call.",
+            toolName: toolCall.name,
+          });
+          duplicateReadonlyResults.set(toolCall, result);
+          return false;
+        });
+
+        // Keep the duplicate visible as a completed tool card while ensuring
+        // it never reaches the MCP bridge.
+        if (duplicateReadonlyResults.size > 0) {
+          ctx.updateSessionMessages(effectiveKey, (currentMessages) =>
+            currentMessages.map((currentMessage) =>
+              currentMessage.id === currentAssistantMessageId
+                ? {
+                    ...currentMessage,
+                    toolCalls: [...duplicateReadonlyResults.entries()].reduce(
+                      (currentToolCalls, [toolCall, result]) =>
+                        updateFirstMatchingToolCall(
+                          currentToolCalls,
+                          toolCall,
+                          ["pending", "running"],
+                          (currentToolCall) => ({
+                            ...currentToolCall,
+                            status: "completed" as const,
+                            result,
+                          }),
+                        ),
+                      currentMessage.toolCalls,
+                    ),
+                  }
+                : currentMessage,
+            ),
+          );
+        }
+
         const authorizationDecisions = await requestToolAuthorizations(
-          toolCalls,
+          executableToolCalls,
           effectiveKey,
           sessionDirId,
         );
@@ -1006,9 +1241,11 @@ export const useAgentLoop = (params: UseAgentLoopParams) => {
         //   AI，Loop 继续，让 AI 根据理由调整后续行动。
         // - 部分拒绝：已拒绝的工具返回拒绝结果给 AI，已批准的工具
         //   正常执行，Loop 继续。
-        const allToolsRejected = authorizationDecisions.every(
-          (decision) => decision.status === "rejected",
-        );
+        const allToolsRejected =
+          executableToolCalls.length > 0 &&
+          authorizationDecisions.every(
+            (decision) => decision.status === "rejected",
+          );
         const hasUserProvidedRejectionReason = authorizationDecisions.some(
           (decision) =>
             decision.status === "rejected" &&
@@ -1031,19 +1268,62 @@ export const useAgentLoop = (params: UseAgentLoopParams) => {
           planModeRef: ctx.planModeRef,
         });
         const toolExecResult = await toolExecutor(
-          toolCalls,
+          executableToolCalls,
           authorizationDecisions,
         );
         if (!toolExecResult) {
           return;
         }
         const {
-          structuredToolResults,
+          structuredToolResults: executedToolResults,
           hookAborted,
           hookAbortMessage,
           userQuestionCancelled,
           pendingHookWarnings,
         } = toolExecResult;
+
+        const structuredToolResults: {
+          name: string;
+          callId: string;
+          result: string;
+        }[] = [];
+        let executedResultIndex = 0;
+        for (const toolCall of toolCalls) {
+          const duplicateResult = duplicateReadonlyResults.get(toolCall);
+          if (duplicateResult !== undefined) {
+            structuredToolResults.push({
+              name: toolCall.name,
+              callId: toolCall.callId || "",
+              result: duplicateResult,
+            });
+            continue;
+          }
+
+          const executedResult = executedToolResults[executedResultIndex++];
+          if (executedResult) {
+            structuredToolResults.push(executedResult);
+          }
+        }
+
+        // Only successful read results are cacheable. Any approved non-read
+        // tool is conservatively treated as a potential state change, which
+        // permits the model to read the same path again after that boundary.
+        for (let index = 0; index < executableToolCalls.length; index++) {
+          const toolCall = executableToolCalls[index];
+          const decision = authorizationDecisions[index];
+          const result = executedToolResults[index]?.result;
+          if (decision?.status !== "approved") {
+            continue;
+          }
+          if (mayMutateWorkspace(toolCall)) {
+            completedReadonlyCalls.clear();
+            continue;
+          }
+          const key = readonlyCallKey(toolCall);
+          if (key && result && !isFailedToolResult(result)) {
+            completedReadonlyCalls.add(key);
+          }
+        }
 
         // Hook abort (exit code 2+): fully interrupt the AI loop and surface
         // the hook's error message. No tool results are sent to the model.
@@ -1096,6 +1376,55 @@ export const useAgentLoop = (params: UseAgentLoopParams) => {
           ...currentMessages,
           toolResultMessage,
         ]);
+        const toolResultsJson = JSON.stringify(structuredToolResults);
+
+        // A duplicate-only batch has no new work to execute. Preserve its
+        // structured results and request one tool-free continuation so the
+        // provider can summarize the already available evidence. The recovery
+        // instruction is request-local and never enters chat history.
+        if (
+          duplicateReadonlyResults.size > 0 &&
+          executableToolCalls.length === 0
+        ) {
+          if (duplicateRecoveryAttempted) {
+            ctx.pendingQueueRef.current.delete(effectiveKey);
+            ctx.setActivePendingMessages([]);
+            if (response.conversationId) {
+              await window.snow.appendToolMessage(
+                response.conversationId,
+                toolResultContent,
+              );
+            }
+            return;
+          }
+          duplicateRecoveryAttempted = true;
+          const recoveryInstruction =
+            "The requested read-only calls have already completed and their results are in the conversation. Do not call tools in this turn. Use the existing results to provide the best final answer.";
+          const recoveryAssistantMessageId = createMessageId("assistant");
+          ctx.updateSessionMessages(effectiveKey, (currentMessages) => [
+            ...currentMessages,
+            {
+              id: recoveryAssistantMessageId,
+              role: "assistant",
+              content: "",
+              timestamp: formatMessageTime(),
+              status: "sending",
+              model: capturedOptions.model,
+            },
+          ]);
+          await runAgentLoop(
+            recoveryAssistantMessageId,
+            [
+              { role: "tool", content: toolResultContent, toolResultsJson },
+            ],
+            response.conversationId,
+            checkpointId,
+            undefined,
+            true,
+            recoveryInstruction,
+          );
+          return;
+        }
 
         if (userQuestionCancelled) {
           ctx.pendingQueueRef.current.delete(effectiveKey);
@@ -1126,7 +1455,6 @@ export const useAgentLoop = (params: UseAgentLoopParams) => {
 
         const pendingQueueForTools =
           ctx.pendingQueueRef.current.get(effectiveKey) ?? [];
-        const toolResultsJson = JSON.stringify(structuredToolResults);
         const nextMessages: {
           role: "user" | "assistant" | "system" | "developer" | "tool";
           content: string;

--- a/src/renderer/components/mainContent/chatMessages/toolCalls/ConfigToolCall.tsx
+++ b/src/renderer/components/mainContent/chatMessages/toolCalls/ConfigToolCall.tsx
@@ -56,6 +56,18 @@ const extractEntries = (data: Record<string, unknown>): unknown[] => {
   return [];
 };
 
+const extractConfigValue = (
+  data: Record<string, unknown>
+): { present: boolean; value: unknown } => {
+  if ("value" in data) {
+    return { present: true, value: data.value };
+  }
+  if ("content" in data) {
+    return { present: true, value: data.content };
+  }
+  return { present: false, value: undefined };
+};
+
 /** get / set 成功后对 value 字段的美化展示（字符串转义解码见 shared/JsonTreeView）。 */
 const ValuePreview = ({ value }: { value: unknown }): React.JSX.Element | null => {
   const { t } = useI18n();
@@ -169,9 +181,9 @@ export const ConfigToolCall = ({
         );
       }
     } else if (operation === "get") {
-      const value = data.value;
+      const { present, value } = extractConfigValue(data);
       meta =
-        value === null ? (
+        !present || value === null || data.exists === false ? (
           <span className="tool-call-config-meta tool-call-config-meta-missing">
             {t("toolCall.config.notConfigured")}
           </span>
@@ -216,6 +228,11 @@ export const ConfigToolCall = ({
     parsedResult.type === "raw"
       ? parsedResult.text
       : "";
+  const configValue =
+    parsedResult.type === "success" &&
+    (operation === "set" || operation === "get")
+      ? extractConfigValue(parsedResult.data)
+      : null;
 
   return (
     <ToolCallNode
@@ -256,10 +273,8 @@ export const ConfigToolCall = ({
           </div>
         ) : null}
 
-        {(parsedResult.type === "success" &&
-        (operation === "set" || operation === "get") &&
-        "value" in parsedResult.data) ? (
-          <ValuePreview value={parsedResult.data.value} />
+        {configValue?.present ? (
+          <ValuePreview value={configValue.value} />
         ) : parsedResult.type === "success" ? (
           <section className="tool-call-section">
             <span className="tool-call-section-label">

--- a/src/renderer/components/mainContent/chatMessages/utils/conversationHelpers.ts
+++ b/src/renderer/components/mainContent/chatMessages/utils/conversationHelpers.ts
@@ -223,24 +223,36 @@ const normalizeToolCallName = (tc: Record<string, unknown>): string => {
 const normalizeToolCallArgumentsFromTc = (
   tc: Record<string, unknown>,
 ): string => {
-  // OpenAI Chat Completions: arguments in tc.function.arguments (string)
-  // OpenAI Responses API: arguments in tc.arguments (object)
-  // Anthropic: input in tc.input (object)
-  // Gemini: args in tc.args (object)
-  if (typeof tc.arguments === "string" || typeof tc.arguments === "object") {
-    return normalizeToolCallArguments(tc.arguments);
+  const candidates = [
+    tc.arguments,
+    tc.args,
+    tc.input,
+    (tc.function as Record<string, unknown> | undefined)?.arguments,
+    (tc.function as Record<string, unknown> | undefined)?.args,
+    (tc.functionCall as Record<string, unknown> | undefined)?.args,
+    (tc.functionCall as Record<string, unknown> | undefined)?.arguments,
+    (tc.function_call as Record<string, unknown> | undefined)?.args,
+    (tc.function_call as Record<string, unknown> | undefined)?.arguments,
+  ];
+
+  for (const cand of candidates) {
+    if (typeof cand === "string") {
+      const trimmed = cand.trim();
+      if (trimmed.length > 0 && trimmed !== "{}") {
+        return trimmed;
+      }
+    } else if (typeof cand === "object" && cand !== null && !Array.isArray(cand)) {
+      if (Object.keys(cand).length > 0) {
+        return JSON.stringify(cand);
+      }
+    }
   }
-  if (typeof tc.input === "string" || typeof tc.input === "object") {
-    return normalizeToolCallArguments(tc.input);
+
+  for (const cand of candidates) {
+    if (typeof cand === "string") return cand;
+    if (typeof cand === "object" && cand !== null) return JSON.stringify(cand);
   }
-  if (typeof tc.args === "string" || typeof tc.args === "object") {
-    return normalizeToolCallArguments(tc.args);
-  }
-  const func = tc.function;
-  if (typeof func === "object" && func !== null && !Array.isArray(func)) {
-    const funcRecord = func as Record<string, unknown>;
-    return normalizeToolCallArguments(funcRecord.arguments);
-  }
+
   return "{}";
 };
 

--- a/src/renderer/components/mainContent/chatMessages/utils/conversationHelpers.ts
+++ b/src/renderer/components/mainContent/chatMessages/utils/conversationHelpers.ts
@@ -200,6 +200,20 @@ const normalizeToolCallName = (tc: Record<string, unknown>): string => {
     }
   }
   if (!name) {
+    const functionCall = tc.functionCall ?? tc.function_call;
+    if (
+      typeof functionCall === "object" &&
+      functionCall !== null &&
+      !Array.isArray(functionCall)
+    ) {
+      const functionCallRecord = functionCall as Record<string, unknown>;
+      name =
+        typeof functionCallRecord.name === "string"
+          ? functionCallRecord.name.trim()
+          : "";
+    }
+  }
+  if (!name) {
     return "";
   }
 
@@ -235,22 +249,67 @@ const normalizeToolCallArgumentsFromTc = (
     (tc.function_call as Record<string, unknown> | undefined)?.arguments,
   ];
 
+  const normalizeCandidate = (candidate: unknown): string | undefined => {
+    if (typeof candidate === "string") {
+      let current: unknown = candidate.trim();
+      // Some relays serialize functionCall/arguments twice. Unwrap only JSON
+      // objects so ordinary string arguments retain their original value.
+      for (let depth = 0; depth < 2 && typeof current === "string"; depth++) {
+        if (!current || current === "{}") break;
+        try {
+          const parsed: unknown = JSON.parse(current);
+          if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+            break;
+          }
+          current = parsed;
+        } catch {
+          break;
+        }
+      }
+      if (typeof current === "string") {
+        return current.length > 0 ? current : undefined;
+      }
+      if (typeof current === "object" && current !== null && !Array.isArray(current)) {
+        return Object.keys(current).length > 0 ? JSON.stringify(current) : undefined;
+      }
+      return undefined;
+    }
+    if (typeof candidate === "object" && candidate !== null && !Array.isArray(candidate)) {
+      return Object.keys(candidate).length > 0 ? JSON.stringify(candidate) : undefined;
+    }
+    return undefined;
+  };
+
   for (const cand of candidates) {
-    if (typeof cand === "string") {
-      const trimmed = cand.trim();
-      if (trimmed.length > 0 && trimmed !== "{}") {
-        return trimmed;
-      }
-    } else if (typeof cand === "object" && cand !== null && !Array.isArray(cand)) {
-      if (Object.keys(cand).length > 0) {
-        return JSON.stringify(cand);
-      }
+    const normalized = normalizeCandidate(cand);
+    if (normalized && normalized !== "{}") {
+      return normalized;
     }
   }
 
   for (const cand of candidates) {
-    if (typeof cand === "string") return cand;
-    if (typeof cand === "object" && cand !== null) return JSON.stringify(cand);
+    const normalized = normalizeCandidate(cand);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  /*
+   * A few Gemini relays wrap the actual call one level below `call` or
+   * `functionCall`. Keep this fallback deliberately narrow: it only unwraps
+   * known provider keys and never guesses arbitrary object fields.
+   */
+  for (const wrapperKey of ["call", "functionCall", "function_call"]) {
+    const wrapper = tc[wrapperKey];
+    if (typeof wrapper === "string") {
+      try {
+        const parsed = JSON.parse(wrapper) as Record<string, unknown>;
+        const nested = normalizeToolCallArgumentsFromTc(parsed);
+        if (nested !== "{}") return nested;
+      } catch {
+        // Keep the empty-argument fallback below.
+      }
+    }
   }
 
   return "{}";
@@ -259,15 +318,34 @@ const normalizeToolCallArgumentsFromTc = (
 const normalizeToolCallId = (
   tc: Record<string, unknown>,
 ): string | undefined => {
-  if (typeof tc.call_id === "string") {
-    return tc.call_id;
+  const readCallId = (record: Record<string, unknown>): string | undefined => {
+    for (const key of ["call_id", "callId", "id"]) {
+      if (typeof record[key] === "string") {
+        return record[key];
+      }
+    }
+    return undefined;
+  };
+
+  const topLevelCallId = readCallId(tc);
+  if (topLevelCallId) {
+    return topLevelCallId;
   }
-  if (typeof tc.callId === "string") {
-    return tc.callId;
+
+  for (const key of ["functionCall", "function_call"]) {
+    const functionCall = tc[key];
+    if (
+      typeof functionCall === "object" &&
+      functionCall !== null &&
+      !Array.isArray(functionCall)
+    ) {
+      const nestedCallId = readCallId(functionCall as Record<string, unknown>);
+      if (nestedCallId) {
+        return nestedCallId;
+      }
+    }
   }
-  if (typeof tc.id === "string") {
-    return tc.id;
-  }
+
   return undefined;
 };
 
@@ -493,9 +571,10 @@ export const validateToolCall = (toolCall: ToolCallInfo): string | null => {
   }
 
   // Validate that arguments is parseable JSON
+  let parsedArguments: unknown = {};
   if (toolCall.arguments) {
     try {
-      JSON.parse(toolCall.arguments);
+      parsedArguments = JSON.parse(toolCall.arguments);
     } catch {
       return JSON.stringify({
         error: `Arguments for tool "${
@@ -506,6 +585,44 @@ export const validateToolCall = (toolCall: ToolCallInfo): string | null => {
         )}. Please provide arguments as a valid JSON object.`,
       });
     }
+  }
+
+  if (
+    typeof parsedArguments !== "object" ||
+    parsedArguments === null ||
+    Array.isArray(parsedArguments)
+  ) {
+    return JSON.stringify({
+      error: `Arguments for tool "${toolCall.name}" must be a JSON object.`,
+    });
+  }
+
+  // Providers may emit a syntactically valid empty object for an incomplete
+  // function call. Do not forward those calls to MCP: its parameter error can
+  // otherwise be replayed to the model and form a retry loop.
+  const requiredStringArguments: Record<string, readonly string[]> = {
+    "filesystem-read": ["filePath"],
+    "filesystem-create": ["filePath", "content"],
+    "filesystem-replace_edit": ["filePath", "searchContent", "replaceContent"],
+    "bash-terminal-execute": ["command"],
+  };
+  const requiredBooleanArguments: Record<string, readonly string[]> = {
+    "filesystem-create": ["overwrite"],
+  };
+  const args = parsedArguments as Record<string, unknown>;
+  const missing = [
+    ...(requiredStringArguments[toolCall.name] ?? []).filter(
+      (key) => typeof args[key] !== "string" || args[key].trim().length === 0,
+    ),
+    ...(requiredBooleanArguments[toolCall.name] ?? []).filter(
+      (key) => typeof args[key] !== "boolean",
+    ),
+  ];
+  if (missing.length > 0) {
+    return JSON.stringify({
+      error: "INVALID_MODEL_TOOL_CALL",
+      message: `Model returned an incomplete call for tool "${toolCall.name}". Missing required arguments: ${missing.join(", ")}. The call was not executed.`,
+    });
   }
 
   return null;

--- a/src/renderer/components/sidebar/apiSettings/ApiSettingsFormFields.tsx
+++ b/src/renderer/components/sidebar/apiSettings/ApiSettingsFormFields.tsx
@@ -403,7 +403,8 @@ export function ApiSettingsFormFields({
               )}
             </div>
           </label>
-          {data.requestMethod === "gemini" && (
+          {(data.requestMethod === "gemini" ||
+            data.requestMethod === "interactions") && (
             <div className="api-settings-field">
               <span>
                 {t("settings.apiGoogleSearch", {

--- a/src/renderer/components/sidebar/apiSettings/apiSettingsConstants.ts
+++ b/src/renderer/components/sidebar/apiSettings/apiSettingsConstants.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_API_BASE_URL = "https://api.openai.com/v1";
 export const DEFAULT_REQUEST_METHOD = "chat";
-export const REQUEST_METHODS = ["chat", "responses", "anthropic", "gemini"];
+export const REQUEST_METHODS = ["chat", "responses", "anthropic", "gemini", "interactions"];
 export const ENABLED_STATUS_LABEL = "Enabled";
 export const DISABLED_STATUS_LABEL = "Not enabled";

--- a/src/renderer/components/sidebar/apiSettings/apiSettingsUtils.ts
+++ b/src/renderer/components/sidebar/apiSettings/apiSettingsUtils.ts
@@ -18,10 +18,15 @@ import {
 } from "../../mainContent/chatInput/constants";
 import type { ApiConfigFormData } from "./types";
 
-type RequestMethod = "chat" | "responses" | "gemini" | "anthropic";
+type RequestMethod = "chat" | "responses" | "gemini" | "anthropic" | "interactions";
 
 const normalizeRequestMethod = (value: string): RequestMethod => {
-  if (value === "responses" || value === "gemini" || value === "anthropic") {
+  if (
+    value === "responses" ||
+    value === "gemini" ||
+    value === "anthropic" ||
+    value === "interactions"
+  ) {
     return value;
   }
   return "chat";
@@ -169,7 +174,7 @@ const buildConfigJsonWithThinking = (
       enabled: isThinkingEnabled,
       effort: thinkingValue,
     };
-  } else if (method === "gemini") {
+  } else if (method === "gemini" || method === "interactions") {
     snowcfg.geminiThinking = {
       enabled: isThinkingEnabled,
       thinkingLevel: thinkingValue,
@@ -213,7 +218,7 @@ export const extractThinkingValueFromConfigJson = (
 
     if (method === "anthropic") {
       section = snowcfg.thinking;
-    } else if (method === "gemini") {
+    } else if (method === "gemini" || method === "interactions") {
       section = snowcfg.geminiThinking;
     } else if (method === "responses") {
       section = snowcfg.responsesReasoning;
@@ -232,7 +237,7 @@ export const extractThinkingValueFromConfigJson = (
     const valueKey =
       method === "anthropic"
         ? "effort"
-        : method === "gemini"
+        : method === "gemini" || method === "interactions"
         ? "thinkingLevel"
         : method === "responses"
         ? "effort"


### PR DESCRIPTION
## Background

This pull request fixes Gemini/CLIProxyAPI-compatible MCP tool calling in Snow App and adds the Google Interactions request path. The primary failures were incomplete or unstable tool-call identifiers, malformed streamed arguments, result/call pairing drift, duplicate readonly tool execution, and provider-specific payload differences.

The PR intentionally contains **8 functional/maintenance commits**. The earlier standalone Rust formatting-only commit has been removed from the PR branch.

## Commit-by-commit changes

### `a0ee40e2` `chore: update .gitignore to exclude AI tooling directories`

Adds ignore rules for local AI-tooling state. This prevents editor/agent-local files from being accidentally included in source-control changes. No runtime behavior changes.

### `a6cee51d` `chore: add .agent/ and GEMINI.md to .gitignore for Antigravity IDE`

Extends the local-tooling ignore coverage for Antigravity/Gemini generated state. No application behavior changes.

### `3bc26c1c` `fix(mcp): ensure tool schemas declare type object and scalar types for Gemini compatibility`

Fixes MCP-to-Gemini function declaration serialization:

- normalizes function parameter roots to `type: object`;
- fills missing scalar schema types where Gemini-compatible validation requires them;
- preserves nested schema structure while producing a valid Gemini function declaration;
- covers browser and generic MCP tool serialization paths.

This prevents Gemini-compatible gateways from rejecting otherwise valid MCP tool definitions because their JSON Schema subset is stricter than the source tool schema.

### `3854f3be` `feat(api): add Google Interactions protocol support and fix tool arguments streaming`

Adds the Google Interactions provider implementation and compatibility handling:

- introduces Interactions endpoint resolution, payload creation, streaming parser, and response normalization;
- supports nested/canonical/legacy event envelopes, step-indexed function calls, split argument deltas, terminal states, usage aliases, thinking summaries, and provider failures;
- keeps function calls and function results paired by provider ID, including repeated calls with the same tool name;
- avoids accepting malformed, truncated, or non-object streamed arguments;
- adds Interactions tool conversion and grouped Google Search/function declaration support;
- threads the provider through model configuration, API dispatch, summary/commit/theme helper requests, and renderer API settings.

This is the core protocol compatibility layer for current Google Interactions-style upstreams.

### `877cf55d` `feat(logs): redact sensitive query credentials in API request logs and fix log filtering`

Hardens API request logging:

- redacts API keys, tokens, and credential-like query parameters before an endpoint is persisted;
- handles malformed URLs, encoded parameter names, duplicated parameters, and case variants;
- keeps enough endpoint diagnostics for troubleshooting;
- corrects log filtering behavior so request-log analysis targets the expected records.

This is especially important for Gemini-compatible endpoints that place credentials in query parameters.

### `cd177142` `fix(renderer): improve agent loop stream metrics accumulation and config tool call rendering`

Repairs renderer-side Agent loop behavior:

- accumulates stream token/latency metrics correctly across chunks;
- keeps configuration tool calls represented consistently in the chat timeline;
- removes stale state paths in sub-agent activation and loop continuation.

This avoids misleading run metrics and improves visibility of configuration-driven tool work.

### `0168c37b` `feat(mcp): support parallel execution for side-effect-free readonly tools`

Adds controlled parallel MCP execution for readonly calls:

- recognizes readonly tool definitions from the registry;
- executes independent readonly calls concurrently while retaining output order;
- preserves sequential execution for side-effecting operations;
- keeps existing approval, cancellation, result formatting, and error behavior.

This reduces latency for common multi-file/project-inspection turns without relaxing mutation safety.

### `6b990406` `fix(gemini): preserve tool results and recover duplicate reads`

Completes Gemini tool-call continuity and duplicate-read recovery across providers:

- extracts nested Gemini `functionCall.id` values and persists them through renderer, IPC, native Rust storage, and replay;
- emits Gemini `functionResponse.id` and keeps same-turn responses grouped in the expected user-role response structure;
- preserves/replays Gemini `thoughtSignature` parts in original provider order, including signature-only and tool-attached parts, without exposing opaque signatures in UI or diagnostics;
- retains same-name parallel calls independently by call ID, while preserving legacy name-only fallback only for legacy ID-less history;
- rejects required built-in tool calls with missing arguments before MCP execution and removes malformed Gemini calls/results from replay history;
- implements one tool-free, history-preserving recovery continuation for a duplicate-only successful readonly batch;
- disables MCP function declarations and configured Google Search during that recovery continuation across Gemini, Interactions, Chat Completions, Responses, and Anthropic payloads;
- prevents a provider that still returns a tool call while tools are disabled from being authorized or executed;
- prevents duplicate readonly MCP execution within an agent run, including Windows-equivalent project paths such as `.`, `D:/...`, and `D:\...`;
- invalidates that readonly cache only after an actual workspace-mutating tool (`filesystem-create`, `filesystem-replace_edit`, or `bash-terminal-execute`), not after TODO bookkeeping;
- adds recovery-only Gemini protocol audit records with payload/response counts but no prompts, file contents, API keys, tool result bodies, or thought signatures.

## Compatibility matrix

| Surface | Covered behavior |
| --- | --- |
| Legacy Gemini `streamGenerateContent` | Function-call IDs, function responses, thought signatures, thinking summaries, replay ordering |
| CLIProxyAPI-compatible Gemini gateways | Nested function-call IDs, usage aliases, parallel same-name calls, compatibility event shapes |
| Google Interactions | Step/index event parsing, split arguments, grouped tools, Google Search option, thinking and usage normalization |
| OpenAI Chat / Responses / Anthropic | Request-local tool-free duplicate recovery instruction and outbound tool suppression |
| MCP runtime | Strict malformed-call rejection, readonly parallelism, duplicate-read execution protection |

## Verification

```text
cargo fmt --manifest-path native/Cargo.toml --check
npm run check:ts
cargo test --manifest-path native/Cargo.toml --workspace -- --test-threads=1
# 70 passed, 0 failed

git diff --check
```

Focused regression coverage includes Gemini signature capture/replay, signature-only parts, matching parallel call IDs, function response IDs, malformed tool-call removal, Interactions split/legacy event parsing, tool/result order, Google Search suppression for tool-free recovery, endpoint credential redaction, and readonly parallel execution.

## Runtime evidence and remaining upstream boundary

Local Electron + SQLite verification confirmed that completed tool results are persisted with matching call IDs and that duplicate readonly calls are withheld from MCP execution. Recovery requests are emitted without MCP declarations or Google Search and are auditable using metadata-only records.

An upstream relay is still responsible for honoring a request with no declared tools. If such a relay returns a function call anyway, Snow records `TOOLS_DISABLED_FOR_DUPLICATE_RECOVERY` and does not authorize or execute it. Snow cannot fabricate a trustworthy final model answer when an upstream refuses to provide final text.
## Scope and non-regression assessment

### What does **not** change on normal requests

| Area | Normal-path behavior retained | Why this PR does not activate there |
| --- | --- | --- |
| Existing Chat Completions / Responses / Anthropic conversations | Existing message history, normal tool declarations, approvals, execution, and final-answer flow remain unchanged | `disableTools` defaults to `false`; the recovery instruction is absent unless a duplicate-only readonly batch is detected |
| Existing Gemini calls with valid tool IDs and arguments | Existing streaming, thinking display, tool UI, and normal continuation flow remain unchanged | ID/signature handling adds preservation and matching; it does not replace valid provider fields or alter normal tool definitions |
| Existing MCP writes and terminal commands | Existing authorization and sequential mutation semantics remain unchanged | Parallel scheduling is restricted to registry-declared readonly tools; mutations remain sequential and retain their approval path |
| Non-Gemini API profiles | Provider selection remains configuration-driven | The new Interactions protocol is selected only for the Interactions request method; adding its implementation does not redirect existing profiles |
| API request logging disabled by default | No new full request-body persistence is introduced | The recovery protocol audit is metadata-only and is emitted only for a duplicate-recovery request |
| User project files and database content | No migration, destructive update, or automatic source-file modification is introduced | The change works at payload, event, renderer-loop, and MCP execution boundaries only |

### Explicitly changed behavior and trigger conditions

1. **Malformed built-in tool calls:** calls missing required arguments are now stopped before MCP execution. This deliberately changes prior behavior that could reach MCP with empty arguments and produce errors such as `filePath is required`.
2. **Duplicate successful readonly calls:** an identical call in the same Agent run is no longer executed twice. Equivalent Windows workspace paths are normalized before comparison. A successful workspace mutation clears this cache, so `read -> write -> read` remains legal.
3. **Duplicate-only recovery:** only when an entire tool batch contains already-completed readonly calls does Snow issue one continuation with tools omitted. It preserves history/tool results; it does not replace the user message or discard context.
4. **Readonly scheduling:** registry-declared readonly calls may execute concurrently. Output order remains the original model-call order. A wrongly classified third-party readonly tool is the relevant operational risk; classification remains governed by the existing registry rather than inferred from the tool name.
5. **Request log redaction:** endpoint query credentials are removed from recorded diagnostics. This intentionally changes log text but not the outbound HTTP request.

### Cross-provider payload safeguards

- Gemini recovery suppresses both MCP `functionDeclarations` and configured `googleSearch` entries.
- Interactions recovery suppresses both grouped function definitions and Google Search.
- Chat Completions, Responses, and Anthropic receive the request-local recovery instruction through their existing system/instruction semantics only when recovery is active.
- The instruction is not appended to user messages, is not persisted as a normal chat message, and is not reused as a sub-agent prompt.
- If an upstream still returns a tool call after tools were omitted, Snow records the condition and rejects execution. It never turns that call into a permission prompt or an MCP invocation.

### Evidence and limits

The automated checks cover Rust unit behavior and TypeScript type compatibility, including negative parsing cases, malformed arguments, ID pairing, signature replay, provider payload suppression, and readonly execution semantics. Local Electron/SQLite verification confirmed persistence and duplicate-execution withholding.

This PR does **not** claim external-provider conformance solely from local tests. A non-conforming relay can still return a function call after receiving no tool declarations; that is handled defensively by Snow but must be accepted by the relay/provider for a normal final text response. Full external acceptance should therefore include a live multi-turn Gemini/CLIProxyAPI run with the target relay.